### PR TITLE
Adding tests for saving out different sized plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Suggests:
     knitr,
     mrgvalidate,
     mrgvalprep (>= 0.0.4),
+    svglite,
     testthat (>= 3.0.0),
     vdiffr,
     yaml,

--- a/tests/testthat/_snaps/base-plot/full-test-big.svg
+++ b/tests/testthat/_snaps/base-plot/full-test-big.svg
@@ -1,0 +1,201 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpODYuMjJ8NzAzLjU2fDI3LjU4fDUwNi43Mw=='>
+    <rect x='86.22' y='27.58' width='617.34' height='479.15' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuMjJ8NzAzLjU2fDI3LjU4fDUwNi43Mw==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw0ODguMjd8NS40OHw1NDcuMzA='>
+    <rect x='5.48' y='5.48' width='482.79' height='541.82' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw0ODguMjd8NS40OHw1NDcuMzA=)'>
+<rect x='5.48' y='5.48' width='482.79' height='541.82' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuMjJ8NDg3LjI4fDI3LjU4fDUwNi43Mw=='>
+    <rect x='86.22' y='27.58' width='401.06' height='479.15' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuMjJ8NDg3LjI4fDI3LjU4fDUwNi43Mw==)'>
+<rect x='86.22' y='27.58' width='401.06' height='479.15' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='124.41,506.73 124.41,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='200.81,506.73 200.81,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='277.20,506.73 277.20,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='353.59,506.73 353.59,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='429.98,506.73 429.98,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='86.22,506.73 86.22,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='162.61,506.73 162.61,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='239.00,506.73 239.00,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='315.39,506.73 315.39,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='391.79,506.73 391.79,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='468.18,506.73 468.18,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='315.39' y1='506.73' x2='315.39' y2='27.58' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27,5.69,4.27; stroke-linecap: butt;' />
+<polyline points='348.61,436.61 348.61,436.61 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='348.61,436.61 302.42,436.61 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='302.42,436.61 302.42,436.61 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='321.37,413.23 321.37,413.23 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='321.37,413.23 301.35,413.23 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='301.35,413.23 301.35,413.23 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='276.38,343.11 276.38,343.11 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='276.38,343.11 253.75,343.11 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='253.75,343.11 253.75,343.11 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='337.79,319.74 337.79,319.74 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='337.79,319.74 328.95,319.74 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='328.95,319.74 328.95,319.74 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='286.83,249.62 286.83,249.62 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='286.83,249.62 278.57,249.62 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='278.57,249.62 278.57,249.62 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='212.58,226.25 212.58,226.25 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='212.58,226.25 187.17,226.25 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='187.17,226.25 187.17,226.25 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='146.26,202.88 146.26,202.88 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='146.26,202.88 111.55,202.88 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='111.55,202.88 111.55,202.88 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='252.20,132.76 252.20,132.76 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='252.20,132.76 252.20,132.76 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='252.20,132.76 252.20,132.76 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='375.27,109.38 375.27,109.38 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='375.27,109.38 375.27,109.38 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='375.27,109.38 375.27,109.38 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polygon points='323.12,439.73 326.24,436.61 323.12,433.49 320.00,436.61 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='311.97,416.35 315.09,413.23 311.97,410.12 308.85,413.23 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='265.76,346.23 268.88,343.11 265.76,340.00 262.64,343.11 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='333.00,322.86 336.12,319.74 333.00,316.62 329.88,319.74 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='282.93,252.74 286.05,249.62 282.93,246.50 279.81,249.62 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='200.35,229.37 203.47,226.25 200.35,223.13 197.24,226.25 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='129.21,206.00 132.33,202.88 129.21,199.76 126.09,202.88 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='252.20,135.88 255.31,132.76 252.20,129.64 249.08,132.76 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<polygon points='375.27,112.50 378.39,109.38 375.27,106.27 372.15,109.38 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<line x1='86.22' y1='74.32' x2='487.28' y2='74.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='86.22' y1='167.82' x2='487.28' y2='167.82' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='86.22' y1='284.68' x2='487.28' y2='284.68' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='86.22' y1='378.17' x2='487.28' y2='378.17' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='239.00' y='27.58' width='171.88' height='876.49' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='86.22,506.73 86.22,27.58 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='81.29' y='77.21' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.60px' lengthAdjust='spacingAndGlyphs'>Weight</text>
+<text x='81.29' y='112.27' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>85 kg</text>
+<text x='81.29' y='135.64' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>55 kg</text>
+<text x='81.29' y='170.70' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='58.31px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
+<text x='81.29' y='205.76' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.42px' lengthAdjust='spacingAndGlyphs'>Severe</text>
+<text x='81.29' y='229.14' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='37.66px' lengthAdjust='spacingAndGlyphs'>Moderate</text>
+<text x='81.29' y='252.51' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='16.26px' lengthAdjust='spacingAndGlyphs'>Mild</text>
+<text x='81.29' y='287.57' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='32.60px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
+<text x='81.29' y='322.63' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='24.70px' lengthAdjust='spacingAndGlyphs'>5 g/dL</text>
+<text x='81.29' y='346.00' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='37.30px' lengthAdjust='spacingAndGlyphs'>3.25 g/dL</text>
+<text x='81.29' y='381.06' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.31px' lengthAdjust='spacingAndGlyphs'>Age</text>
+<text x='81.29' y='416.12' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>45 years</text>
+<text x='81.29' y='439.49' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>20 years</text>
+<polyline points='83.48,74.32 86.22,74.32 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,109.38 86.22,109.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,132.76 86.22,132.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,167.82 86.22,167.82 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,202.88 86.22,202.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,226.25 86.22,226.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,249.62 86.22,249.62 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,284.68 86.22,284.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,319.74 86.22,319.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,343.11 86.22,343.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,378.17 86.22,378.17 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,413.23 86.22,413.23 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,436.61 86.22,436.61 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='86.22,506.73 487.28,506.73 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='86.22,509.47 86.22,506.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='162.61,509.47 162.61,506.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='239.00,509.47 239.00,506.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='315.39,509.47 315.39,506.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='391.79,509.47 391.79,506.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='468.18,509.47 468.18,506.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='86.22' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='162.61' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='239.00' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='315.39' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='391.79' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='468.18' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='286.75' y='529.04' text-anchor='middle' style='font-size: 9.92px; font-family: Liberation Sans;' textLength='102.62px' lengthAdjust='spacingAndGlyphs'>Fraction and 95% CI </text>
+<text x='286.75' y='539.76' text-anchor='middle' style='font-size: 9.92px; font-family: Liberation Sans;' textLength='106.10px' lengthAdjust='spacingAndGlyphs'>Relative to Reference</text>
+<text x='86.22' y='19.63' style='font-size: 11.91px; font-family: Liberation Sans;' textLength='51.03px' lengthAdjust='spacingAndGlyphs'>CL (L/hr)</text>
+</g>
+<defs>
+  <clipPath id='cpNDg4LjI3fDcxNC41Mnw1LjQ4fDU0Ny4zMA=='>
+    <rect x='488.27' y='5.48' width='226.25' height='541.82' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDg4LjI3fDcxNC41Mnw1LjQ4fDU0Ny4zMA==)'>
+<rect x='488.27' y='5.48' width='226.25' height='541.82' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTAzLjAzfDcwMy41NnwyNy41OHw1MDYuNzM='>
+    <rect x='503.03' y='27.58' width='200.53' height='479.15' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTAzLjAzfDcwMy41NnwyNy41OHw1MDYuNzM=)'>
+<rect x='503.03' y='27.58' width='200.53' height='479.15' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='503.03' y='74.32' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='27.71px' lengthAdjust='spacingAndGlyphs'>Weight</text>
+<text x='503.03' y='109.38' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.2 [1.2, 1.2]</text>
+<text x='503.03' y='132.76' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.83 [0.83, 0.83]</text>
+<text x='503.03' y='167.82' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='58.56px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
+<text x='503.03' y='202.88' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.51 [0.47, 0.56]</text>
+<text x='503.03' y='226.25' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.70 [0.66, 0.73]</text>
+<text x='503.03' y='249.62' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.92 [0.90, 0.93]</text>
+<text x='503.03' y='284.68' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='32.74px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
+<text x='503.03' y='319.74' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.0 [1.0, 1.1]</text>
+<text x='503.03' y='343.11' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.87 [0.84, 0.90]</text>
+<text x='503.03' y='378.17' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='15.39px' lengthAdjust='spacingAndGlyphs'>Age</text>
+<text x='503.03' y='413.23' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='61.86px' lengthAdjust='spacingAndGlyphs'>0.99 [0.96, 1.0]</text>
+<text x='503.03' y='436.61' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='56.80px' lengthAdjust='spacingAndGlyphs'>1.0 [0.97, 1.1]</text>
+<line x1='503.03' y1='81.34' x2='703.56' y2='81.34' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='503.03' y1='174.83' x2='703.56' y2='174.83' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='503.03' y1='291.69' x2='703.56' y2='291.69' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='503.03' y1='385.19' x2='703.56' y2='385.19' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='503.03,506.73 703.56,506.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='503.03,509.47 503.03,506.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='543.14,509.47 543.14,506.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='583.24,509.47 583.24,506.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.35,509.47 623.35,506.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='663.46,509.47 663.46,506.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='703.56,509.47 703.56,506.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='503.03' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='543.14' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='583.24' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='623.35' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.3</text>
+<text x='663.46' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='703.56' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='503.03' y='19.63' style='font-size: 11.91px; font-family: Liberation Sans;' textLength='98.29px' lengthAdjust='spacingAndGlyphs'>Median [95% CI]</text>
+<text x='703.56' y='559.19' text-anchor='end' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='130.33px' lengthAdjust='spacingAndGlyphs'>The shaded area corresponds</text>
+<text x='703.56' y='568.69' text-anchor='end' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='164.29px' lengthAdjust='spacingAndGlyphs'>                   to the interval (0.8, 1.25)</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/base-plot/full-test-small.svg
+++ b/tests/testthat/_snaps/base-plot/full-test-small.svg
@@ -1,0 +1,201 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='216.00pt' height='216.00pt' viewBox='0 0 216.00 216.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHwyMTYuMDB8MC4wMHwyMTYuMDA='>
+    <rect x='0.00' y='0.00' width='216.00' height='216.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHwyMTYuMDB8MC4wMHwyMTYuMDA=)'>
+<rect x='0.00' y='0.00' width='216.00' height='216.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpODYuMjJ8MTk5LjU2fDI3LjU4fDE0Ni43Mw=='>
+    <rect x='86.22' y='27.58' width='113.34' height='119.15' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuMjJ8MTk5LjU2fDI3LjU4fDE0Ni43Mw==)'>
+</g>
+<g clip-path='url(#cpMC4wMHwyMTYuMDB8MC4wMHwyMTYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNTIuMjd8NS40OHwxODcuMzA='>
+    <rect x='5.48' y='5.48' width='146.79' height='181.82' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNTIuMjd8NS40OHwxODcuMzA=)'>
+<rect x='5.48' y='5.48' width='146.79' height='181.82' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHwyMTYuMDB8MC4wMHwyMTYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuMjJ8MTUxLjI4fDI3LjU4fDE0Ni43Mw=='>
+    <rect x='86.22' y='27.58' width='65.06' height='119.15' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuMjJ8MTUxLjI4fDI3LjU4fDE0Ni43Mw==)'>
+<rect x='86.22' y='27.58' width='65.06' height='119.15' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='92.41,146.73 92.41,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='104.81,146.73 104.81,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='117.20,146.73 117.20,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='129.59,146.73 129.59,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='141.98,146.73 141.98,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='86.22,146.73 86.22,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='98.61,146.73 98.61,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='111.00,146.73 111.00,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='123.39,146.73 123.39,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='135.79,146.73 135.79,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='148.18,146.73 148.18,27.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='123.39' y1='146.73' x2='123.39' y2='27.58' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27,5.69,4.27; stroke-linecap: butt;' />
+<polyline points='128.78,129.29 128.78,129.29 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='128.78,129.29 121.29,129.29 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='121.29,129.29 121.29,129.29 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='124.36,123.48 124.36,123.48 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='124.36,123.48 121.12,123.48 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='121.12,123.48 121.12,123.48 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='117.07,106.04 117.07,106.04 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='117.07,106.04 113.39,106.04 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='113.39,106.04 113.39,106.04 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='127.03,100.23 127.03,100.23 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='127.03,100.23 125.59,100.23 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='125.59,100.23 125.59,100.23 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='118.76,82.79 118.76,82.79 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='118.76,82.79 117.42,82.79 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='117.42,82.79 117.42,82.79 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='106.71,76.98 106.71,76.98 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='106.71,76.98 102.59,76.98 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='102.59,76.98 102.59,76.98 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='95.96,71.17 95.96,71.17 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='95.96,71.17 90.33,71.17 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='90.33,71.17 90.33,71.17 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='113.14,53.73 113.14,53.73 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='113.14,53.73 113.14,53.73 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='113.14,53.73 113.14,53.73 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='133.11,47.92 133.11,47.92 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='133.11,47.92 133.11,47.92 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='133.11,47.92 133.11,47.92 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polygon points='124.65,132.41 127.77,129.29 124.65,126.17 121.53,129.29 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='122.84,126.60 125.96,123.48 122.84,120.36 119.72,123.48 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='115.34,109.16 118.46,106.04 115.34,102.92 112.22,106.04 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='126.25,103.35 129.37,100.23 126.25,97.11 123.13,100.23 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='118.13,85.91 121.25,82.79 118.13,79.67 115.01,82.79 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='104.73,80.10 107.85,76.98 104.73,73.86 101.61,76.98 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='93.19,74.29 96.31,71.17 93.19,68.05 90.07,71.17 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='113.14,56.85 116.26,53.73 113.14,50.61 110.02,53.73 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<polygon points='133.11,51.04 136.22,47.92 133.11,44.80 129.99,47.92 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<line x1='86.22' y1='39.20' x2='151.28' y2='39.20' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='86.22' y1='62.45' x2='151.28' y2='62.45' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='86.22' y1='91.51' x2='151.28' y2='91.51' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='86.22' y1='114.76' x2='151.28' y2='114.76' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='111.00' y='27.58' width='27.88' height='217.95' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
+</g>
+<g clip-path='url(#cpMC4wMHwyMTYuMDB8MC4wMHwyMTYuMDA=)'>
+<polyline points='86.22,146.73 86.22,27.58 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='81.29' y='42.09' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.60px' lengthAdjust='spacingAndGlyphs'>Weight</text>
+<text x='81.29' y='50.81' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>85 kg</text>
+<text x='81.29' y='56.62' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>55 kg</text>
+<text x='81.29' y='65.34' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='58.31px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
+<text x='81.29' y='74.06' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.42px' lengthAdjust='spacingAndGlyphs'>Severe</text>
+<text x='81.29' y='79.87' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='37.66px' lengthAdjust='spacingAndGlyphs'>Moderate</text>
+<text x='81.29' y='85.68' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='16.26px' lengthAdjust='spacingAndGlyphs'>Mild</text>
+<text x='81.29' y='94.40' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='32.60px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
+<text x='81.29' y='103.12' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='24.70px' lengthAdjust='spacingAndGlyphs'>5 g/dL</text>
+<text x='81.29' y='108.93' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='37.30px' lengthAdjust='spacingAndGlyphs'>3.25 g/dL</text>
+<text x='81.29' y='117.65' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.31px' lengthAdjust='spacingAndGlyphs'>Age</text>
+<text x='81.29' y='126.36' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>45 years</text>
+<text x='81.29' y='132.18' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>20 years</text>
+<polyline points='83.48,39.20 86.22,39.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,47.92 86.22,47.92 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,53.73 86.22,53.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,62.45 86.22,62.45 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,71.17 86.22,71.17 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,76.98 86.22,76.98 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,82.79 86.22,82.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,91.51 86.22,91.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,100.23 86.22,100.23 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,106.04 86.22,106.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,114.76 86.22,114.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,123.48 86.22,123.48 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='83.48,129.29 86.22,129.29 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='86.22,146.73 151.28,146.73 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='86.22,149.47 86.22,146.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='98.61,149.47 98.61,146.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='111.00,149.47 111.00,146.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='123.39,149.47 123.39,146.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='135.79,149.47 135.79,146.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='148.18,149.47 148.18,146.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='86.22' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='98.61' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='111.00' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='123.39' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='135.79' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='148.18' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='118.75' y='169.04' text-anchor='middle' style='font-size: 9.92px; font-family: Liberation Sans;' textLength='102.62px' lengthAdjust='spacingAndGlyphs'>Fraction and 95% CI </text>
+<text x='118.75' y='179.76' text-anchor='middle' style='font-size: 9.92px; font-family: Liberation Sans;' textLength='106.10px' lengthAdjust='spacingAndGlyphs'>Relative to Reference</text>
+<text x='86.22' y='19.63' style='font-size: 11.91px; font-family: Liberation Sans;' textLength='51.03px' lengthAdjust='spacingAndGlyphs'>CL (L/hr)</text>
+</g>
+<defs>
+  <clipPath id='cpMTUyLjI3fDIxMC41Mnw1LjQ4fDE4Ny4zMA=='>
+    <rect x='152.27' y='5.48' width='58.25' height='181.82' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTUyLjI3fDIxMC41Mnw1LjQ4fDE4Ny4zMA==)'>
+<rect x='152.27' y='5.48' width='58.25' height='181.82' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHwyMTYuMDB8MC4wMHwyMTYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTY3LjAzfDE5OS41NnwyNy41OHwxNDYuNzM='>
+    <rect x='167.03' y='27.58' width='32.53' height='119.15' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTY3LjAzfDE5OS41NnwyNy41OHwxNDYuNzM=)'>
+<rect x='167.03' y='27.58' width='32.53' height='119.15' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='167.03' y='39.20' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='27.71px' lengthAdjust='spacingAndGlyphs'>Weight</text>
+<text x='167.03' y='47.92' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.2 [1.2, 1.2]</text>
+<text x='167.03' y='53.73' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.83 [0.83, 0.83]</text>
+<text x='167.03' y='62.45' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='58.56px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
+<text x='167.03' y='71.17' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.51 [0.47, 0.56]</text>
+<text x='167.03' y='76.98' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.70 [0.66, 0.73]</text>
+<text x='167.03' y='82.79' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.92 [0.90, 0.93]</text>
+<text x='167.03' y='91.51' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='32.74px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
+<text x='167.03' y='100.23' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.0 [1.0, 1.1]</text>
+<text x='167.03' y='106.04' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.87 [0.84, 0.90]</text>
+<text x='167.03' y='114.76' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='15.39px' lengthAdjust='spacingAndGlyphs'>Age</text>
+<text x='167.03' y='123.48' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='61.86px' lengthAdjust='spacingAndGlyphs'>0.99 [0.96, 1.0]</text>
+<text x='167.03' y='129.29' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='56.80px' lengthAdjust='spacingAndGlyphs'>1.0 [0.97, 1.1]</text>
+<line x1='167.03' y1='40.95' x2='199.56' y2='40.95' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='167.03' y1='64.19' x2='199.56' y2='64.19' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='167.03' y1='93.26' x2='199.56' y2='93.26' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='167.03' y1='116.50' x2='199.56' y2='116.50' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHwyMTYuMDB8MC4wMHwyMTYuMDA=)'>
+<polyline points='167.03,146.73 199.56,146.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='167.03,149.47 167.03,146.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='173.54,149.47 173.54,146.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='180.04,149.47 180.04,146.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='186.55,149.47 186.55,146.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='193.06,149.47 193.06,146.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='199.56,149.47 199.56,146.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='167.03' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='173.54' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='180.04' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='186.55' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.3</text>
+<text x='193.06' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='199.56' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='167.03' y='19.63' style='font-size: 11.91px; font-family: Liberation Sans;' textLength='98.29px' lengthAdjust='spacingAndGlyphs'>Median [95% CI]</text>
+<text x='199.56' y='199.19' text-anchor='end' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='130.33px' lengthAdjust='spacingAndGlyphs'>The shaded area corresponds</text>
+<text x='199.56' y='208.69' text-anchor='end' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='164.29px' lengthAdjust='spacingAndGlyphs'>                   to the interval (0.8, 1.25)</text>
+</g>
+</svg>

--- a/tests/testthat/test-base-plot.R
+++ b/tests/testthat/test-base-plot.R
@@ -254,6 +254,37 @@ describe("Base plots", {
 
   })
 
+  it("Plot alignment with different saving to different sizes [PMF-PLOT-024]", {
+    skip_on_cran()
+    skip_vdiffr()
+    plt <- plot_forest(data = sumData,
+                       shaded_interval = c(0.8,1.25),
+                       summary_label = plot_labels,
+                       text_size = 3.5,
+                       digits = 2,
+                       vline_intercept = 1,
+                       x_lab = "Fraction and 95% CI \nRelative to Reference",
+                       CI_label = "Median [95% CI]",
+                       caption = "The shaded area corresponds
+                   to the interval (0.8, 1.25)",
+                   plot_width = 8,
+                   x_breaks = c(0.4,0.6, 0.8, 1, 1.2, 1.4,1.6),
+                   x_limit = c(0.4,1.45),
+                   ggplot_theme = theme_classic(),
+                   shape_size = 2,
+                   annotate_CI=T
+    )
+
+    save_small <- function(plot, file, title = "") {
+      ggplot2::ggsave(file, plot, device = "svg", height = 3, width = 3)
+    }
+    save_big <- function(plot, file, title = "") {
+      ggplot2::ggsave(file, plot, device = "svg", height = 8, width = 10)
+    }
+    vdiffr::expect_doppelganger("Full Test - small", plt, writer = save_small)
+    vdiffr::expect_doppelganger("Full Test - big", plt, writer = save_big)
+  })
+
 })
 
 


### PR DESCRIPTION
Addressing the point made in https://github.com/metrumresearchgroup/pmforest/issues/11#issuecomment-1054500429

> Another key test will be when you change the size of the plot... Whatever solution we implement, let's make sure there are vdiffr tests that explicitly output bigger and smaller plots, to be sure the alignment still looks right.