### PR TITLE
Updating test refs, March 2022

### DIFF
--- a/tests/testthat/_snaps/nsim-plot/multiple-simulations.svg
+++ b/tests/testthat/_snaps/nsim-plot/multiple-simulations.svg
@@ -105,15 +105,15 @@
 <circle cx='103.01' cy='210.44' r='0.46' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
 <circle cx='263.98' cy='139.29' r='0.46' style='stroke-width: 0.71; stroke: #C77CFF; fill: #C77CFF;' />
 <circle cx='415.70' cy='115.57' r='0.46' style='stroke-width: 0.71; stroke: #C77CFF; fill: #C77CFF;' />
-<line x1='334.29' y1='447.64' x2='337.42' y2='447.64' style='stroke-width: 1.49; stroke: #F8766D; stroke-linecap: butt;' />
-<line x1='331.54' y1='423.92' x2='334.27' y2='423.92' style='stroke-width: 1.49; stroke: #F8766D; stroke-linecap: butt;' />
-<line x1='273.13' y1='352.76' x2='276.23' y2='352.76' style='stroke-width: 1.49; stroke: #7CAE00; stroke-linecap: butt;' />
-<line x1='360.48' y1='329.04' x2='363.01' y2='329.04' style='stroke-width: 1.49; stroke: #7CAE00; stroke-linecap: butt;' />
-<line x1='299.38' y1='257.88' x2='301.50' y2='257.88' style='stroke-width: 1.49; stroke: #00BFC4; stroke-linecap: butt;' />
-<line x1='190.74' y1='234.16' x2='194.57' y2='234.16' style='stroke-width: 1.49; stroke: #00BFC4; stroke-linecap: butt;' />
-<line x1='99.31' y1='210.44' x2='103.01' y2='210.44' style='stroke-width: 1.49; stroke: #00BFC4; stroke-linecap: butt;' />
-<line x1='262.46' y1='139.29' x2='263.98' y2='139.29' style='stroke-width: 1.49; stroke: #C77CFF; stroke-linecap: butt;' />
-<line x1='414.16' y1='115.57' x2='415.70' y2='115.57' style='stroke-width: 1.49; stroke: #C77CFF; stroke-linecap: butt;' />
+<line x1='334.29' y1='447.64' x2='342.98' y2='447.64' style='stroke-width: 1.49; stroke: #F8766D; stroke-linecap: butt;' />
+<line x1='331.54' y1='423.92' x2='336.06' y2='423.92' style='stroke-width: 1.49; stroke: #F8766D; stroke-linecap: butt;' />
+<line x1='273.13' y1='352.76' x2='278.81' y2='352.76' style='stroke-width: 1.49; stroke: #7CAE00; stroke-linecap: butt;' />
+<line x1='360.48' y1='329.04' x2='366.25' y2='329.04' style='stroke-width: 1.49; stroke: #7CAE00; stroke-linecap: butt;' />
+<line x1='299.38' y1='257.88' x2='303.76' y2='257.88' style='stroke-width: 1.49; stroke: #00BFC4; stroke-linecap: butt;' />
+<line x1='190.74' y1='234.16' x2='198.16' y2='234.16' style='stroke-width: 1.49; stroke: #00BFC4; stroke-linecap: butt;' />
+<line x1='99.31' y1='210.44' x2='107.52' y2='210.44' style='stroke-width: 1.49; stroke: #00BFC4; stroke-linecap: butt;' />
+<line x1='262.46' y1='139.29' x2='265.55' y2='139.29' style='stroke-width: 1.49; stroke: #C77CFF; stroke-linecap: butt;' />
+<line x1='414.16' y1='115.57' x2='417.27' y2='115.57' style='stroke-width: 1.49; stroke: #C77CFF; stroke-linecap: butt;' />
 <circle cx='418.38' cy='447.64' r='0.46' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
 <circle cx='391.42' cy='423.92' r='0.46' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
 <circle cx='336.19' cy='352.76' r='0.46' style='stroke-width: 0.71; stroke: #7CAE00; fill: #7CAE00;' />


### PR DESCRIPTION
Fixing two test issues described as "unrelated" in #17 

The second one `'nsim-plot/multiple-simulations.svg' has changed` is fixed by b332d5259cfb0f0db4132db996854a70d384a975

The first one `SVG snapshot generated under a different vdiffr version.` I can't replicate. I used `pkgr install --update` to get the latest version of everything that we pull from CRAN (and did see `installed_version=1.0.2 pkg=vdiffr update_version=1.0.4`) but I'm still not seeing the skip.

```
> devtools::test()
ℹ Loading pmforest
ℹ Testing pmforest
✓ | F W S  OK | Context
✓ |        22 | base-plot [10.5s]                                                                                                                          
✓ |         3 | input-data [0.2s]                                                                                                                          
✓ |         2 | nsim-plot [2.5s]                                                                                                                           
✓ |         5 | summary [1.0s]                                                                                                                             

══ Results ════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 14.2 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 32 ]
> packageVersion("vdiffr")
[1] ‘1.0.4’
```

I will say that that specific test is the only one to use a [custom writer function](https://github.com/metrumresearchgroup/pmforest/blob/main/tests/testthat/test-base-plot.R#L278-L285), for saving out svg's of a non-standard size. It's not obvious to me why that would cause this, but it also seem unlikely to be a coincidence.