### PR TITLE
Fix README typo

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -42,7 +42,7 @@ You can find documentation and a "Getting Started" vignette that shows users how
 
 ### Featured Vignettes
 
-* [Getting Started with bbr](https://metrumresearchgroup.github.io/pmforest/articles/getting-started.html) -- Data specifications, summarization, and basic plotting methods.
+* [Getting Started](https://metrumresearchgroup.github.io/pmforest/articles/getting-started.html) -- Data specifications, summarization, and basic plotting methods.
 * [Multiple Simulations](https://metrumresearchgroup.github.io/pmforest/articles/multiple-simulations.html) -- Plotting additional confidence intervals over the 'replicate' or simulation run.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ highlighted as well.
 
 ### Featured Vignettes
 
--   [Getting Started](https://metrumresearchgroup.github.io/pmforest/articles/getting-started.html)
+-   [Getting
+    Started](https://metrumresearchgroup.github.io/pmforest/articles/getting-started.html)
     – Data specifications, summarization, and basic plotting methods.
 -   [Multiple
     Simulations](https://metrumresearchgroup.github.io/pmforest/articles/multiple-simulations.html)


### PR DESCRIPTION
Looks like this was fixed in the .md, but should be fixed here instead?