### PR TITLE
Fix group_level when printing a character of a number

### DIFF
--- a/R/classicforest.R
+++ b/R/classicforest.R
@@ -40,11 +40,7 @@ classicforest <- function(plotdata,
   y_limit <- c(min(plotdata$ID) - 3, max(plotdata$ID) + text_size)
   y_tick_names <-
     c(as.vector(group_level), as.vector(summary_label))[order(c(plotdata$ID, madata$ID), decreasing = T)]
-  suppressWarnings({
-    if(any(is.na(as.numeric(y_tick_names)))){
-      y_tick_names[!is.na(as.numeric(y_tick_names))] <- ""
-    }
-  })
+
   y_breaks <- sort(c(plotdata$ID, madata$ID), decreasing = T)
   y_lines <- sort(madata$ID, decreasing = T)
 

--- a/R/forest-constructor.R
+++ b/R/forest-constructor.R
@@ -98,7 +98,7 @@ forest_constructor <- function(data,
     if (!is.null(group_level) && length(group_level) != n) {
       warning("Argument group_level has wrong length and is ignored.")
     }
-    group_level <- 1:n
+    group_level <- rep("", n)
   }
 
   # if not exactly one name for every subgroup is supplied the default is used

--- a/inst/validation/pmforest-stories.yaml
+++ b/inst/validation/pmforest-stories.yaml
@@ -105,6 +105,7 @@ DATA-S003:
   - PMF-DATA-001
   - PMF-DATA-002
   - PMF-PLOT-019
+  - PMF-PLOT-024
 DATA-S004:
   name: Summarize across replicates
   description: As a user, I want to calculate median, lower, and upper quantile, for

--- a/tests/testthat/_snaps/base-plot/chacter-interpretation-of-numeric-group-level.svg
+++ b/tests/testthat/_snaps/base-plot/chacter-interpretation-of-numeric-group-level.svg
@@ -1,0 +1,186 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDkuNTd8NzAzLjU2fDQ0LjQxfDU0MS4zNw=='>
+    <rect x='49.57' y='44.41' width='653.99' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkuNTd8NzAzLjU2fDQ0LjQxfDU0MS4zNw==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw0NzYuMzJ8MjIuNzh8NTcwLjUy'>
+    <rect x='5.48' y='22.78' width='470.84' height='547.74' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw0NzYuMzJ8MjIuNzh8NTcwLjUy)'>
+<rect x='5.48' y='22.78' width='470.84' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkuNTd8NDc1LjMyfDQ0LjQxfDU0MS4zNw=='>
+    <rect x='49.57' y='44.41' width='425.75' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkuNTd8NDc1LjMyfDQ0LjQxfDU0MS4zNw==)'>
+<rect x='49.57' y='44.41' width='425.75' height='496.97' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='87.80,541.37 87.80,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='199.92,541.37 199.92,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='312.04,541.37 312.04,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='424.15,541.37 424.15,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='143.86,541.37 143.86,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='255.98,541.37 255.98,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='368.10,541.37 368.10,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='-192.50' y1='541.37' x2='-192.50' y2='44.41' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27,5.69,4.27; stroke-linecap: butt;' />
+<polyline points='416.85,468.65 416.85,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='416.85,468.65 349.05,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='349.05,468.65 349.05,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='376.86,444.40 376.86,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='376.86,444.40 347.49,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='347.49,444.40 347.49,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='310.84,371.68 310.84,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='310.84,371.68 277.62,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='277.62,371.68 277.62,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='400.97,347.43 400.97,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='400.97,347.43 387.99,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='387.99,347.43 387.99,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='326.17,274.71 326.17,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='326.17,274.71 314.04,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='314.04,274.71 314.04,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='217.20,250.47 217.20,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='217.20,250.47 179.90,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='179.90,250.47 179.90,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='119.86,226.22 119.86,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='119.86,226.22 68.92,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='68.92,226.22 68.92,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='275.34,153.50 275.34,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='275.34,153.50 275.34,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='275.34,153.50 275.34,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='455.97,129.26 455.97,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='455.97,129.26 455.97,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='455.97,129.26 455.97,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polygon points='379.44,473.77 384.56,468.65 379.44,463.52 374.31,468.65 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='363.08,449.53 368.20,444.40 363.08,439.28 357.95,444.40 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='295.24,376.80 300.37,371.68 295.24,366.55 290.12,371.68 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='393.94,352.56 399.06,347.43 393.94,342.31 388.82,347.43 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='320.45,279.83 325.57,274.71 320.45,269.58 315.32,274.71 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='199.25,255.59 204.38,250.47 199.25,245.34 194.13,250.47 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='94.83,231.35 99.96,226.22 94.83,221.10 89.71,226.22 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='275.34,158.62 280.46,153.50 275.34,148.37 270.22,153.50 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<polygon points='455.97,134.38 461.09,129.26 455.97,124.13 450.85,129.26 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<line x1='49.57' y1='92.89' x2='475.32' y2='92.89' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='49.57' y1='189.86' x2='475.32' y2='189.86' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='49.57' y1='311.07' x2='475.32' y2='311.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='49.57' y1='408.04' x2='475.32' y2='408.04' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='49.57' y='44.41' width='425.75' height='496.97' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='44.64' y='95.62' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='12.34px' lengthAdjust='spacingAndGlyphs'>WT</text>
+<text x='44.64' y='131.99' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='44.64' y='156.23' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='44.64' y='192.59' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='22.05px' lengthAdjust='spacingAndGlyphs'>EGFR</text>
+<text x='44.64' y='228.95' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='44.64' y='253.20' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='44.64' y='277.44' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='44.64' y='313.80' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='15.01px' lengthAdjust='spacingAndGlyphs'>ALB</text>
+<text x='44.64' y='350.17' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='44.64' y='374.41' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='44.64' y='410.77' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='16.77px' lengthAdjust='spacingAndGlyphs'>AGE</text>
+<text x='44.64' y='447.13' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='44.64' y='471.38' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>1</text>
+<polyline points='46.83,92.89 49.57,92.89 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,129.26 49.57,129.26 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,153.50 49.57,153.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,189.86 49.57,189.86 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,226.22 49.57,226.22 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,250.47 49.57,250.47 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,274.71 49.57,274.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,311.07 49.57,311.07 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,347.43 49.57,347.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,371.68 49.57,371.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,408.04 49.57,408.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,444.40 49.57,444.40 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,468.65 49.57,468.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='143.86,544.11 143.86,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='255.98,544.11 255.98,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='368.10,544.11 368.10,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='143.86' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='255.98' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='368.10' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='262.45' y='562.98' text-anchor='middle' style='font-size: 9.92px; font-family: sans;' textLength='25.37px' lengthAdjust='spacingAndGlyphs'>Effect</text>
+</g>
+<defs>
+  <clipPath id='cpNDc2LjMyfDcxNC41MnwyMi43OHw1NzAuNTI='>
+    <rect x='476.32' y='22.78' width='238.20' height='547.74' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDc2LjMyfDcxNC41MnwyMi43OHw1NzAuNTI=)'>
+<rect x='476.32' y='22.78' width='238.20' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkwLjY5fDcwMy41Nnw0NC40MXw1NDEuMzc='>
+    <rect x='490.69' y='44.41' width='212.88' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkwLjY5fDcwMy41Nnw0NC40MXw1NDEuMzc=)'>
+<rect x='490.69' y='44.41' width='212.88' height='496.97' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='490.69' y='92.89' style='font-size: 7.97px; font-family: sans;' textLength='12.39px' lengthAdjust='spacingAndGlyphs'>WT</text>
+<text x='490.69' y='129.26' style='font-size: 7.97px; font-family: sans;' textLength='57.59px' lengthAdjust='spacingAndGlyphs'>1.16 [1.16, 1.16]</text>
+<text x='490.69' y='153.50' style='font-size: 7.97px; font-family: sans;' textLength='70.88px' lengthAdjust='spacingAndGlyphs'>0.835 [0.835, 0.835]</text>
+<text x='490.69' y='189.86' style='font-size: 7.97px; font-family: sans;' textLength='22.14px' lengthAdjust='spacingAndGlyphs'>EGFR</text>
+<text x='490.69' y='226.22' style='font-size: 7.97px; font-family: sans;' textLength='70.88px' lengthAdjust='spacingAndGlyphs'>0.513 [0.466, 0.557]</text>
+<text x='490.69' y='250.47' style='font-size: 7.97px; font-family: sans;' textLength='70.88px' lengthAdjust='spacingAndGlyphs'>0.699 [0.664, 0.731]</text>
+<text x='490.69' y='274.71' style='font-size: 7.97px; font-family: sans;' textLength='70.88px' lengthAdjust='spacingAndGlyphs'>0.915 [0.904, 0.925]</text>
+<text x='490.69' y='311.07' style='font-size: 7.97px; font-family: sans;' textLength='15.06px' lengthAdjust='spacingAndGlyphs'>ALB</text>
+<text x='490.69' y='347.43' style='font-size: 7.97px; font-family: sans;' textLength='57.59px' lengthAdjust='spacingAndGlyphs'>1.05 [1.04, 1.06]</text>
+<text x='490.69' y='371.68' style='font-size: 7.97px; font-family: sans;' textLength='70.88px' lengthAdjust='spacingAndGlyphs'>0.870 [0.839, 0.898]</text>
+<text x='490.69' y='408.04' style='font-size: 7.97px; font-family: sans;' textLength='16.83px' lengthAdjust='spacingAndGlyphs'>AGE</text>
+<text x='490.69' y='444.40' style='font-size: 7.97px; font-family: sans;' textLength='66.45px' lengthAdjust='spacingAndGlyphs'>0.991 [0.963, 1.02]</text>
+<text x='490.69' y='468.65' style='font-size: 7.97px; font-family: sans;' textLength='62.02px' lengthAdjust='spacingAndGlyphs'>1.02 [0.966, 1.09]</text>
+<line x1='490.69' y1='100.16' x2='703.56' y2='100.16' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='490.69' y1='197.13' x2='703.56' y2='197.13' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='490.69' y1='318.34' x2='703.56' y2='318.34' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='490.69' y1='415.31' x2='703.56' y2='415.31' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='490.69,541.37 703.56,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='490.69,544.11 490.69,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='533.26,544.11 533.26,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='575.84,544.11 575.84,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='618.41,544.11 618.41,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='660.99,544.11 660.99,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='703.56,544.11 703.56,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='490.69' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='533.26' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='575.84' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='618.41' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.3</text>
+<text x='660.99' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='703.56' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='490.69' y='36.46' style='font-size: 11.91px; font-family: sans;' textLength='30.44px' lengthAdjust='spacingAndGlyphs'>Effect</text>
+<text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='264.16px' lengthAdjust='spacingAndGlyphs'>Chacter interpretation of numeric group_level</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/base-plot/character-interpretation-of-numeric-group-level.svg
+++ b/tests/testthat/_snaps/base-plot/character-interpretation-of-numeric-group-level.svg
@@ -181,6 +181,6 @@
 <text x='660.99' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.4</text>
 <text x='703.56' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.5</text>
 <text x='490.69' y='36.46' style='font-size: 11.91px; font-family: sans;' textLength='30.44px' lengthAdjust='spacingAndGlyphs'>Effect</text>
-<text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='264.16px' lengthAdjust='spacingAndGlyphs'>Chacter interpretation of numeric group_level</text>
+<text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='275.90px' lengthAdjust='spacingAndGlyphs'>Character interpretation of numeric group_level</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/base-plot/full-test-big.svg
+++ b/tests/testthat/_snaps/base-plot/full-test-big.svg
@@ -9,6 +9,9 @@
       stroke-linejoin: round;
       stroke-miterlimit: 10.00;
     }
+    .svglite text {
+      white-space: pre;
+    }
   ]]></style>
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
@@ -98,23 +101,23 @@
 <line x1='86.22' y1='167.82' x2='487.28' y2='167.82' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='86.22' y1='284.68' x2='487.28' y2='284.68' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='86.22' y1='378.17' x2='487.28' y2='378.17' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<rect x='239.00' y='27.58' width='171.88' height='876.49' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
+<rect x='239.00' y='27.58' width='171.88' height='876.49' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polyline points='86.22,506.73 86.22,27.58 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<text x='81.29' y='77.21' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.60px' lengthAdjust='spacingAndGlyphs'>Weight</text>
-<text x='81.29' y='112.27' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>85 kg</text>
-<text x='81.29' y='135.64' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>55 kg</text>
-<text x='81.29' y='170.70' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='58.31px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
-<text x='81.29' y='205.76' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.42px' lengthAdjust='spacingAndGlyphs'>Severe</text>
-<text x='81.29' y='229.14' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='37.66px' lengthAdjust='spacingAndGlyphs'>Moderate</text>
-<text x='81.29' y='252.51' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='16.26px' lengthAdjust='spacingAndGlyphs'>Mild</text>
-<text x='81.29' y='287.57' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='32.60px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
-<text x='81.29' y='322.63' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='24.70px' lengthAdjust='spacingAndGlyphs'>5 g/dL</text>
-<text x='81.29' y='346.00' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='37.30px' lengthAdjust='spacingAndGlyphs'>3.25 g/dL</text>
-<text x='81.29' y='381.06' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.31px' lengthAdjust='spacingAndGlyphs'>Age</text>
-<text x='81.29' y='416.12' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>45 years</text>
-<text x='81.29' y='439.49' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>20 years</text>
+<text x='81.29' y='77.21' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='27.60px' lengthAdjust='spacingAndGlyphs'>Weight</text>
+<text x='81.29' y='112.27' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>85 kg</text>
+<text x='81.29' y='135.64' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>55 kg</text>
+<text x='81.29' y='170.70' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='58.31px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
+<text x='81.29' y='205.76' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='27.42px' lengthAdjust='spacingAndGlyphs'>Severe</text>
+<text x='81.29' y='229.14' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='37.66px' lengthAdjust='spacingAndGlyphs'>Moderate</text>
+<text x='81.29' y='252.51' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.26px' lengthAdjust='spacingAndGlyphs'>Mild</text>
+<text x='81.29' y='287.57' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='32.60px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
+<text x='81.29' y='322.63' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='24.70px' lengthAdjust='spacingAndGlyphs'>5 g/dL</text>
+<text x='81.29' y='346.00' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='37.30px' lengthAdjust='spacingAndGlyphs'>3.25 g/dL</text>
+<text x='81.29' y='381.06' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='15.31px' lengthAdjust='spacingAndGlyphs'>Age</text>
+<text x='81.29' y='416.12' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>45 years</text>
+<text x='81.29' y='439.49' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>20 years</text>
 <polyline points='83.48,74.32 86.22,74.32 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='83.48,109.38 86.22,109.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='83.48,132.76 86.22,132.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
@@ -135,15 +138,15 @@
 <polyline points='315.39,509.47 315.39,506.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='391.79,509.47 391.79,506.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='468.18,509.47 468.18,506.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='86.22' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.4</text>
-<text x='162.61' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.6</text>
-<text x='239.00' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.8</text>
-<text x='315.39' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='391.79' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
-<text x='468.18' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
-<text x='286.75' y='529.04' text-anchor='middle' style='font-size: 9.92px; font-family: Liberation Sans;' textLength='102.62px' lengthAdjust='spacingAndGlyphs'>Fraction and 95% CI </text>
-<text x='286.75' y='539.76' text-anchor='middle' style='font-size: 9.92px; font-family: Liberation Sans;' textLength='106.10px' lengthAdjust='spacingAndGlyphs'>Relative to Reference</text>
-<text x='86.22' y='19.63' style='font-size: 11.91px; font-family: Liberation Sans;' textLength='51.03px' lengthAdjust='spacingAndGlyphs'>CL (L/hr)</text>
+<text x='86.22' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='162.61' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='239.00' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='315.39' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='391.79' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='468.18' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='286.75' y='529.04' text-anchor='middle' style='font-size: 9.92px; font-family: "Liberation Sans";' textLength='102.62px' lengthAdjust='spacingAndGlyphs'>Fraction and 95% CI </text>
+<text x='286.75' y='539.76' text-anchor='middle' style='font-size: 9.92px; font-family: "Liberation Sans";' textLength='106.10px' lengthAdjust='spacingAndGlyphs'>Relative to Reference</text>
+<text x='86.22' y='19.63' style='font-size: 11.91px; font-family: "Liberation Sans";' textLength='51.03px' lengthAdjust='spacingAndGlyphs'>CL (L/hr)</text>
 </g>
 <defs>
   <clipPath id='cpNDg4LjI3fDcxNC41Mnw1LjQ4fDU0Ny4zMA=='>
@@ -162,19 +165,19 @@
 </defs>
 <g clip-path='url(#cpNTAzLjAzfDcwMy41NnwyNy41OHw1MDYuNzM=)'>
 <rect x='503.03' y='27.58' width='200.53' height='479.15' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='503.03' y='74.32' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='27.71px' lengthAdjust='spacingAndGlyphs'>Weight</text>
-<text x='503.03' y='109.38' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.2 [1.2, 1.2]</text>
-<text x='503.03' y='132.76' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.83 [0.83, 0.83]</text>
-<text x='503.03' y='167.82' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='58.56px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
-<text x='503.03' y='202.88' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.51 [0.47, 0.56]</text>
-<text x='503.03' y='226.25' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.70 [0.66, 0.73]</text>
-<text x='503.03' y='249.62' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.92 [0.90, 0.93]</text>
-<text x='503.03' y='284.68' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='32.74px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
-<text x='503.03' y='319.74' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.0 [1.0, 1.1]</text>
-<text x='503.03' y='343.11' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.87 [0.84, 0.90]</text>
-<text x='503.03' y='378.17' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='15.39px' lengthAdjust='spacingAndGlyphs'>Age</text>
-<text x='503.03' y='413.23' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='61.86px' lengthAdjust='spacingAndGlyphs'>0.99 [0.96, 1.0]</text>
-<text x='503.03' y='436.61' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='56.80px' lengthAdjust='spacingAndGlyphs'>1.0 [0.97, 1.1]</text>
+<text x='503.03' y='74.32' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='27.71px' lengthAdjust='spacingAndGlyphs'>Weight</text>
+<text x='503.03' y='109.38' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.2 [1.2, 1.2]</text>
+<text x='503.03' y='132.76' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.83 [0.83, 0.83]</text>
+<text x='503.03' y='167.82' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='58.56px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
+<text x='503.03' y='202.88' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.51 [0.47, 0.56]</text>
+<text x='503.03' y='226.25' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.70 [0.66, 0.73]</text>
+<text x='503.03' y='249.62' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.92 [0.90, 0.93]</text>
+<text x='503.03' y='284.68' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='32.74px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
+<text x='503.03' y='319.74' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.0 [1.0, 1.1]</text>
+<text x='503.03' y='343.11' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.87 [0.84, 0.90]</text>
+<text x='503.03' y='378.17' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='15.39px' lengthAdjust='spacingAndGlyphs'>Age</text>
+<text x='503.03' y='413.23' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='61.86px' lengthAdjust='spacingAndGlyphs'>0.99 [0.96, 1.0]</text>
+<text x='503.03' y='436.61' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='56.80px' lengthAdjust='spacingAndGlyphs'>1.0 [0.97, 1.1]</text>
 <line x1='503.03' y1='81.34' x2='703.56' y2='81.34' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='503.03' y1='174.83' x2='703.56' y2='174.83' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='503.03' y1='291.69' x2='703.56' y2='291.69' style='stroke-width: 1.07; stroke-linecap: butt;' />
@@ -188,14 +191,14 @@
 <polyline points='623.35,509.47 623.35,506.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='663.46,509.47 663.46,506.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='703.56,509.47 703.56,506.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<text x='503.03' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='543.14' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.1</text>
-<text x='583.24' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
-<text x='623.35' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.3</text>
-<text x='663.46' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
-<text x='703.56' y='517.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='503.03' y='19.63' style='font-size: 11.91px; font-family: Liberation Sans;' textLength='98.29px' lengthAdjust='spacingAndGlyphs'>Median [95% CI]</text>
-<text x='703.56' y='559.19' text-anchor='end' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='130.33px' lengthAdjust='spacingAndGlyphs'>The shaded area corresponds</text>
-<text x='703.56' y='568.69' text-anchor='end' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='164.29px' lengthAdjust='spacingAndGlyphs'>                   to the interval (0.8, 1.25)</text>
+<text x='503.03' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='543.14' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='583.24' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='623.35' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.3</text>
+<text x='663.46' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='703.56' y='517.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='503.03' y='19.63' style='font-size: 11.91px; font-family: "Liberation Sans";' textLength='98.29px' lengthAdjust='spacingAndGlyphs'>Median [95% CI]</text>
+<text x='703.56' y='559.19' text-anchor='end' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='130.33px' lengthAdjust='spacingAndGlyphs'>The shaded area corresponds</text>
+<text x='703.56' y='568.69' text-anchor='end' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='164.29px' lengthAdjust='spacingAndGlyphs'>                   to the interval (0.8, 1.25)</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/base-plot/full-test-small.svg
+++ b/tests/testthat/_snaps/base-plot/full-test-small.svg
@@ -9,6 +9,9 @@
       stroke-linejoin: round;
       stroke-miterlimit: 10.00;
     }
+    .svglite text {
+      white-space: pre;
+    }
   ]]></style>
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
@@ -98,23 +101,23 @@
 <line x1='86.22' y1='62.45' x2='151.28' y2='62.45' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='86.22' y1='91.51' x2='151.28' y2='91.51' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='86.22' y1='114.76' x2='151.28' y2='114.76' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<rect x='111.00' y='27.58' width='27.88' height='217.95' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
+<rect x='111.00' y='27.58' width='27.88' height='217.95' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
 </g>
 <g clip-path='url(#cpMC4wMHwyMTYuMDB8MC4wMHwyMTYuMDA=)'>
 <polyline points='86.22,146.73 86.22,27.58 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<text x='81.29' y='42.09' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.60px' lengthAdjust='spacingAndGlyphs'>Weight</text>
-<text x='81.29' y='50.81' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>85 kg</text>
-<text x='81.29' y='56.62' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>55 kg</text>
-<text x='81.29' y='65.34' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='58.31px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
-<text x='81.29' y='74.06' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.42px' lengthAdjust='spacingAndGlyphs'>Severe</text>
-<text x='81.29' y='79.87' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='37.66px' lengthAdjust='spacingAndGlyphs'>Moderate</text>
-<text x='81.29' y='85.68' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='16.26px' lengthAdjust='spacingAndGlyphs'>Mild</text>
-<text x='81.29' y='94.40' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='32.60px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
-<text x='81.29' y='103.12' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='24.70px' lengthAdjust='spacingAndGlyphs'>5 g/dL</text>
-<text x='81.29' y='108.93' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='37.30px' lengthAdjust='spacingAndGlyphs'>3.25 g/dL</text>
-<text x='81.29' y='117.65' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.31px' lengthAdjust='spacingAndGlyphs'>Age</text>
-<text x='81.29' y='126.36' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>45 years</text>
-<text x='81.29' y='132.18' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>20 years</text>
+<text x='81.29' y='42.09' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='27.60px' lengthAdjust='spacingAndGlyphs'>Weight</text>
+<text x='81.29' y='50.81' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>85 kg</text>
+<text x='81.29' y='56.62' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='22.21px' lengthAdjust='spacingAndGlyphs'>55 kg</text>
+<text x='81.29' y='65.34' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='58.31px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
+<text x='81.29' y='74.06' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='27.42px' lengthAdjust='spacingAndGlyphs'>Severe</text>
+<text x='81.29' y='79.87' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='37.66px' lengthAdjust='spacingAndGlyphs'>Moderate</text>
+<text x='81.29' y='85.68' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.26px' lengthAdjust='spacingAndGlyphs'>Mild</text>
+<text x='81.29' y='94.40' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='32.60px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
+<text x='81.29' y='103.12' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='24.70px' lengthAdjust='spacingAndGlyphs'>5 g/dL</text>
+<text x='81.29' y='108.93' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='37.30px' lengthAdjust='spacingAndGlyphs'>3.25 g/dL</text>
+<text x='81.29' y='117.65' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='15.31px' lengthAdjust='spacingAndGlyphs'>Age</text>
+<text x='81.29' y='126.36' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>45 years</text>
+<text x='81.29' y='132.18' text-anchor='end' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='34.39px' lengthAdjust='spacingAndGlyphs'>20 years</text>
 <polyline points='83.48,39.20 86.22,39.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='83.48,47.92 86.22,47.92 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='83.48,53.73 86.22,53.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
@@ -135,15 +138,15 @@
 <polyline points='123.39,149.47 123.39,146.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='135.79,149.47 135.79,146.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='148.18,149.47 148.18,146.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='86.22' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.4</text>
-<text x='98.61' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.6</text>
-<text x='111.00' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.8</text>
-<text x='123.39' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='135.79' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
-<text x='148.18' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
-<text x='118.75' y='169.04' text-anchor='middle' style='font-size: 9.92px; font-family: Liberation Sans;' textLength='102.62px' lengthAdjust='spacingAndGlyphs'>Fraction and 95% CI </text>
-<text x='118.75' y='179.76' text-anchor='middle' style='font-size: 9.92px; font-family: Liberation Sans;' textLength='106.10px' lengthAdjust='spacingAndGlyphs'>Relative to Reference</text>
-<text x='86.22' y='19.63' style='font-size: 11.91px; font-family: Liberation Sans;' textLength='51.03px' lengthAdjust='spacingAndGlyphs'>CL (L/hr)</text>
+<text x='86.22' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='98.61' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='111.00' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='123.39' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='135.79' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='148.18' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='118.75' y='169.04' text-anchor='middle' style='font-size: 9.92px; font-family: "Liberation Sans";' textLength='102.62px' lengthAdjust='spacingAndGlyphs'>Fraction and 95% CI </text>
+<text x='118.75' y='179.76' text-anchor='middle' style='font-size: 9.92px; font-family: "Liberation Sans";' textLength='106.10px' lengthAdjust='spacingAndGlyphs'>Relative to Reference</text>
+<text x='86.22' y='19.63' style='font-size: 11.91px; font-family: "Liberation Sans";' textLength='51.03px' lengthAdjust='spacingAndGlyphs'>CL (L/hr)</text>
 </g>
 <defs>
   <clipPath id='cpMTUyLjI3fDIxMC41Mnw1LjQ4fDE4Ny4zMA=='>
@@ -162,19 +165,19 @@
 </defs>
 <g clip-path='url(#cpMTY3LjAzfDE5OS41NnwyNy41OHwxNDYuNzM=)'>
 <rect x='167.03' y='27.58' width='32.53' height='119.15' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='167.03' y='39.20' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='27.71px' lengthAdjust='spacingAndGlyphs'>Weight</text>
-<text x='167.03' y='47.92' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.2 [1.2, 1.2]</text>
-<text x='167.03' y='53.73' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.83 [0.83, 0.83]</text>
-<text x='167.03' y='62.45' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='58.56px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
-<text x='167.03' y='71.17' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.51 [0.47, 0.56]</text>
-<text x='167.03' y='76.98' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.70 [0.66, 0.73]</text>
-<text x='167.03' y='82.79' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.92 [0.90, 0.93]</text>
-<text x='167.03' y='91.51' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='32.74px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
-<text x='167.03' y='100.23' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.0 [1.0, 1.1]</text>
-<text x='167.03' y='106.04' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.87 [0.84, 0.90]</text>
-<text x='167.03' y='114.76' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='15.39px' lengthAdjust='spacingAndGlyphs'>Age</text>
-<text x='167.03' y='123.48' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='61.86px' lengthAdjust='spacingAndGlyphs'>0.99 [0.96, 1.0]</text>
-<text x='167.03' y='129.29' style='font-size: 7.97px; font-family: Liberation Sans;' textLength='56.80px' lengthAdjust='spacingAndGlyphs'>1.0 [0.97, 1.1]</text>
+<text x='167.03' y='39.20' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='27.71px' lengthAdjust='spacingAndGlyphs'>Weight</text>
+<text x='167.03' y='47.92' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.2 [1.2, 1.2]</text>
+<text x='167.03' y='53.73' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.83 [0.83, 0.83]</text>
+<text x='167.03' y='62.45' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='58.56px' lengthAdjust='spacingAndGlyphs'>Renal Function</text>
+<text x='167.03' y='71.17' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.51 [0.47, 0.56]</text>
+<text x='167.03' y='76.98' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.70 [0.66, 0.73]</text>
+<text x='167.03' y='82.79' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.92 [0.90, 0.93]</text>
+<text x='167.03' y='91.51' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='32.74px' lengthAdjust='spacingAndGlyphs'>Albumin</text>
+<text x='167.03' y='100.23' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='51.74px' lengthAdjust='spacingAndGlyphs'>1.0 [1.0, 1.1]</text>
+<text x='167.03' y='106.04' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='66.92px' lengthAdjust='spacingAndGlyphs'>0.87 [0.84, 0.90]</text>
+<text x='167.03' y='114.76' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='15.39px' lengthAdjust='spacingAndGlyphs'>Age</text>
+<text x='167.03' y='123.48' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='61.86px' lengthAdjust='spacingAndGlyphs'>0.99 [0.96, 1.0]</text>
+<text x='167.03' y='129.29' style='font-size: 7.97px; font-family: "Liberation Sans";' textLength='56.80px' lengthAdjust='spacingAndGlyphs'>1.0 [0.97, 1.1]</text>
 <line x1='167.03' y1='40.95' x2='199.56' y2='40.95' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='167.03' y1='64.19' x2='199.56' y2='64.19' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='167.03' y1='93.26' x2='199.56' y2='93.26' style='stroke-width: 1.07; stroke-linecap: butt;' />
@@ -188,14 +191,14 @@
 <polyline points='186.55,149.47 186.55,146.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='193.06,149.47 193.06,146.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='199.56,149.47 199.56,146.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<text x='167.03' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='173.54' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.1</text>
-<text x='180.04' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
-<text x='186.55' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.3</text>
-<text x='193.06' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
-<text x='199.56' y='157.43' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='167.03' y='19.63' style='font-size: 11.91px; font-family: Liberation Sans;' textLength='98.29px' lengthAdjust='spacingAndGlyphs'>Median [95% CI]</text>
-<text x='199.56' y='199.19' text-anchor='end' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='130.33px' lengthAdjust='spacingAndGlyphs'>The shaded area corresponds</text>
-<text x='199.56' y='208.69' text-anchor='end' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='164.29px' lengthAdjust='spacingAndGlyphs'>                   to the interval (0.8, 1.25)</text>
+<text x='167.03' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='173.54' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='180.04' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='186.55' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.3</text>
+<text x='193.06' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='199.56' y='157.43' text-anchor='middle' style='font-size: 7.94px;fill: #FFFFFF; font-family: "Liberation Sans";' textLength='12.60px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='167.03' y='19.63' style='font-size: 11.91px; font-family: "Liberation Sans";' textLength='98.29px' lengthAdjust='spacingAndGlyphs'>Median [95% CI]</text>
+<text x='199.56' y='199.19' text-anchor='end' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='130.33px' lengthAdjust='spacingAndGlyphs'>The shaded area corresponds</text>
+<text x='199.56' y='208.69' text-anchor='end' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='164.29px' lengthAdjust='spacingAndGlyphs'>                   to the interval (0.8, 1.25)</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/base-plot/full-test.svg
+++ b/tests/testthat/_snaps/base-plot/full-test.svg
@@ -98,7 +98,7 @@
 <line x1='80.91' y1='180.03' x2='485.77' y2='180.03' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='80.91' y1='293.05' x2='485.77' y2='293.05' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='80.91' y1='383.47' x2='485.77' y2='383.47' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<rect x='235.14' y='44.41' width='173.51' height='847.65' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
+<rect x='235.14' y='44.41' width='173.51' height='847.65' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polyline points='80.91,507.79 80.91,44.41 ' style='stroke-width: 1.07; stroke-linecap: butt;' />

--- a/tests/testthat/_snaps/base-plot/numeric-group-level.svg
+++ b/tests/testthat/_snaps/base-plot/numeric-group-level.svg
@@ -1,0 +1,186 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDkuNTd8NzAzLjU2fDQ0LjQxfDU0MS4zNw=='>
+    <rect x='49.57' y='44.41' width='653.99' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkuNTd8NzAzLjU2fDQ0LjQxfDU0MS4zNw==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw0NzYuMzJ8MjIuNzh8NTcwLjUy'>
+    <rect x='5.48' y='22.78' width='470.84' height='547.74' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw0NzYuMzJ8MjIuNzh8NTcwLjUy)'>
+<rect x='5.48' y='22.78' width='470.84' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkuNTd8NDc1LjMyfDQ0LjQxfDU0MS4zNw=='>
+    <rect x='49.57' y='44.41' width='425.75' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkuNTd8NDc1LjMyfDQ0LjQxfDU0MS4zNw==)'>
+<rect x='49.57' y='44.41' width='425.75' height='496.97' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='87.80,541.37 87.80,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='199.92,541.37 199.92,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='312.04,541.37 312.04,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='424.15,541.37 424.15,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='143.86,541.37 143.86,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='255.98,541.37 255.98,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='368.10,541.37 368.10,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='-192.50' y1='541.37' x2='-192.50' y2='44.41' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27,5.69,4.27; stroke-linecap: butt;' />
+<polyline points='416.85,468.65 416.85,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='416.85,468.65 349.05,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='349.05,468.65 349.05,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='376.86,444.40 376.86,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='376.86,444.40 347.49,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='347.49,444.40 347.49,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='310.84,371.68 310.84,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='310.84,371.68 277.62,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='277.62,371.68 277.62,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='400.97,347.43 400.97,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='400.97,347.43 387.99,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='387.99,347.43 387.99,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='326.17,274.71 326.17,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='326.17,274.71 314.04,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='314.04,274.71 314.04,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='217.20,250.47 217.20,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='217.20,250.47 179.90,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='179.90,250.47 179.90,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='119.86,226.22 119.86,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='119.86,226.22 68.92,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='68.92,226.22 68.92,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='275.34,153.50 275.34,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='275.34,153.50 275.34,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='275.34,153.50 275.34,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='455.97,129.26 455.97,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='455.97,129.26 455.97,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='455.97,129.26 455.97,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polygon points='379.44,473.77 384.56,468.65 379.44,463.52 374.31,468.65 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='363.08,449.53 368.20,444.40 363.08,439.28 357.95,444.40 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='295.24,376.80 300.37,371.68 295.24,366.55 290.12,371.68 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='393.94,352.56 399.06,347.43 393.94,342.31 388.82,347.43 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='320.45,279.83 325.57,274.71 320.45,269.58 315.32,274.71 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='199.25,255.59 204.38,250.47 199.25,245.34 194.13,250.47 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='94.83,231.35 99.96,226.22 94.83,221.10 89.71,226.22 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='275.34,158.62 280.46,153.50 275.34,148.37 270.22,153.50 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<polygon points='455.97,134.38 461.09,129.26 455.97,124.13 450.85,129.26 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<line x1='49.57' y1='92.89' x2='475.32' y2='92.89' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='49.57' y1='189.86' x2='475.32' y2='189.86' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='49.57' y1='311.07' x2='475.32' y2='311.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='49.57' y1='408.04' x2='475.32' y2='408.04' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='49.57' y='44.41' width='425.75' height='496.97' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='44.64' y='95.62' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='12.34px' lengthAdjust='spacingAndGlyphs'>WT</text>
+<text x='44.64' y='131.99' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='44.64' y='156.23' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='44.64' y='192.59' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='22.05px' lengthAdjust='spacingAndGlyphs'>EGFR</text>
+<text x='44.64' y='228.95' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='44.64' y='253.20' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='44.64' y='277.44' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='44.64' y='313.80' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='15.01px' lengthAdjust='spacingAndGlyphs'>ALB</text>
+<text x='44.64' y='350.17' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='44.64' y='374.41' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='44.64' y='410.77' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='16.77px' lengthAdjust='spacingAndGlyphs'>AGE</text>
+<text x='44.64' y='447.13' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='44.64' y='471.38' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>1</text>
+<polyline points='46.83,92.89 49.57,92.89 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,129.26 49.57,129.26 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,153.50 49.57,153.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,189.86 49.57,189.86 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,226.22 49.57,226.22 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,250.47 49.57,250.47 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,274.71 49.57,274.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,311.07 49.57,311.07 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,347.43 49.57,347.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,371.68 49.57,371.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,408.04 49.57,408.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,444.40 49.57,444.40 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='46.83,468.65 49.57,468.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='143.86,544.11 143.86,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='255.98,544.11 255.98,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='368.10,544.11 368.10,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='143.86' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='255.98' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='368.10' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='262.45' y='562.98' text-anchor='middle' style='font-size: 9.92px; font-family: sans;' textLength='25.37px' lengthAdjust='spacingAndGlyphs'>Effect</text>
+</g>
+<defs>
+  <clipPath id='cpNDc2LjMyfDcxNC41MnwyMi43OHw1NzAuNTI='>
+    <rect x='476.32' y='22.78' width='238.20' height='547.74' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDc2LjMyfDcxNC41MnwyMi43OHw1NzAuNTI=)'>
+<rect x='476.32' y='22.78' width='238.20' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkwLjY5fDcwMy41Nnw0NC40MXw1NDEuMzc='>
+    <rect x='490.69' y='44.41' width='212.88' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkwLjY5fDcwMy41Nnw0NC40MXw1NDEuMzc=)'>
+<rect x='490.69' y='44.41' width='212.88' height='496.97' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='490.69' y='92.89' style='font-size: 7.97px; font-family: sans;' textLength='12.39px' lengthAdjust='spacingAndGlyphs'>WT</text>
+<text x='490.69' y='129.26' style='font-size: 7.97px; font-family: sans;' textLength='57.59px' lengthAdjust='spacingAndGlyphs'>1.16 [1.16, 1.16]</text>
+<text x='490.69' y='153.50' style='font-size: 7.97px; font-family: sans;' textLength='70.88px' lengthAdjust='spacingAndGlyphs'>0.835 [0.835, 0.835]</text>
+<text x='490.69' y='189.86' style='font-size: 7.97px; font-family: sans;' textLength='22.14px' lengthAdjust='spacingAndGlyphs'>EGFR</text>
+<text x='490.69' y='226.22' style='font-size: 7.97px; font-family: sans;' textLength='70.88px' lengthAdjust='spacingAndGlyphs'>0.513 [0.466, 0.557]</text>
+<text x='490.69' y='250.47' style='font-size: 7.97px; font-family: sans;' textLength='70.88px' lengthAdjust='spacingAndGlyphs'>0.699 [0.664, 0.731]</text>
+<text x='490.69' y='274.71' style='font-size: 7.97px; font-family: sans;' textLength='70.88px' lengthAdjust='spacingAndGlyphs'>0.915 [0.904, 0.925]</text>
+<text x='490.69' y='311.07' style='font-size: 7.97px; font-family: sans;' textLength='15.06px' lengthAdjust='spacingAndGlyphs'>ALB</text>
+<text x='490.69' y='347.43' style='font-size: 7.97px; font-family: sans;' textLength='57.59px' lengthAdjust='spacingAndGlyphs'>1.05 [1.04, 1.06]</text>
+<text x='490.69' y='371.68' style='font-size: 7.97px; font-family: sans;' textLength='70.88px' lengthAdjust='spacingAndGlyphs'>0.870 [0.839, 0.898]</text>
+<text x='490.69' y='408.04' style='font-size: 7.97px; font-family: sans;' textLength='16.83px' lengthAdjust='spacingAndGlyphs'>AGE</text>
+<text x='490.69' y='444.40' style='font-size: 7.97px; font-family: sans;' textLength='66.45px' lengthAdjust='spacingAndGlyphs'>0.991 [0.963, 1.02]</text>
+<text x='490.69' y='468.65' style='font-size: 7.97px; font-family: sans;' textLength='62.02px' lengthAdjust='spacingAndGlyphs'>1.02 [0.966, 1.09]</text>
+<line x1='490.69' y1='100.16' x2='703.56' y2='100.16' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='490.69' y1='197.13' x2='703.56' y2='197.13' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='490.69' y1='318.34' x2='703.56' y2='318.34' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='490.69' y1='415.31' x2='703.56' y2='415.31' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='490.69,541.37 703.56,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='490.69,544.11 490.69,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='533.26,544.11 533.26,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='575.84,544.11 575.84,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='618.41,544.11 618.41,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='660.99,544.11 660.99,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='703.56,544.11 703.56,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='490.69' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='533.26' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='575.84' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='618.41' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.3</text>
+<text x='660.99' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='703.56' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='490.69' y='36.46' style='font-size: 11.91px; font-family: sans;' textLength='30.44px' lengthAdjust='spacingAndGlyphs'>Effect</text>
+<text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='121.07px' lengthAdjust='spacingAndGlyphs'>Numeric group_level</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/base-plot/shaded-interval.svg
+++ b/tests/testthat/_snaps/base-plot/shaded-interval.svg
@@ -94,7 +94,7 @@
 <line x1='61.05' y1='189.86' x2='479.15' y2='189.86' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='61.05' y1='311.07' x2='479.15' y2='311.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <line x1='61.05' y1='408.04' x2='479.15' y2='408.04' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<rect x='263.75' y='44.41' width='247.73' height='909.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
+<rect x='263.75' y='44.41' width='247.73' height='909.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
 <rect x='61.05' y='44.41' width='418.10' height='496.97' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>

--- a/tests/testthat/_snaps/nsim-plot/multiple-ci-s-with-jitter.svg
+++ b/tests/testthat/_snaps/nsim-plot/multiple-ci-s-with-jitter.svg
@@ -152,7 +152,7 @@
 <line x1='135.24' y1='219.40' x2='197.00' y2='219.40' style='stroke-width: 1.49; stroke: #00BFC4; stroke-linecap: butt;' />
 <line x1='263.02' y1='150.70' x2='322.92' y2='150.70' style='stroke-width: 1.49; stroke: #C77CFF; stroke-linecap: butt;' />
 <line x1='388.48' y1='127.80' x2='448.40' y2='127.80' style='stroke-width: 1.49; stroke: #C77CFF; stroke-linecap: butt;' />
-<rect x='246.80' y='45.93' width='175.16' height='870.22' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
+<rect x='246.80' y='45.93' width='175.16' height='870.22' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
 <rect x='89.80' y='45.93' width='398.08' height='480.91' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>

--- a/tests/testthat/_snaps/nsim-plot/multiple-simulations.svg
+++ b/tests/testthat/_snaps/nsim-plot/multiple-simulations.svg
@@ -150,7 +150,7 @@
 <line x1='135.17' y1='210.44' x2='139.12' y2='210.44' style='stroke-width: 1.49; stroke: #00BFC4; stroke-linecap: butt;' />
 <line x1='287.33' y1='139.29' x2='291.05' y2='139.29' style='stroke-width: 1.49; stroke: #C77CFF; stroke-linecap: butt;' />
 <line x1='438.56' y1='115.57' x2='442.87' y2='115.57' style='stroke-width: 1.49; stroke: #C77CFF; stroke-linecap: butt;' />
-<rect x='273.01' y='44.41' width='211.65' height='889.48' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
+<rect x='273.01' y='44.41' width='211.65' height='889.48' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959; fill-opacity: 0.20;' />
 <rect x='80.91' y='44.41' width='404.86' height='486.25' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>

--- a/tests/testthat/test-base-plot.R
+++ b/tests/testthat/test-base-plot.R
@@ -285,6 +285,29 @@ describe("Base plots", {
     vdiffr::expect_doppelganger("Full Test - big", plt, writer = save_big)
   })
 
+
+  it("group_level works with numeric data [PMF-PLOT-024]", {
+    skip_on_cran()
+    skip_vdiffr()
+    df <- plotData %>%
+      summarize_data(
+        value = stat,
+        group = GROUP,
+        group_level = LVL
+      )
+    df <- df %>% mutate(group_level = 1:dplyr::n())
+
+    plt1 <- plot_forest(df)
+    vdiffr::expect_doppelganger("Numeric group_level", plt1)
+
+    # Character representations of numeric data (e.g. '10.0' also used to not work)
+    # Test for this as well
+    df <- df %>% mutate(group_level = as.character(group_level))
+
+    plt2 <- plot_forest(df)
+    vdiffr::expect_doppelganger("Chacter interpretation of numeric group_level", plt2)
+
+  })
 })
 
 

--- a/tests/testthat/test-base-plot.R
+++ b/tests/testthat/test-base-plot.R
@@ -305,7 +305,7 @@ describe("Base plots", {
     df <- df %>% mutate(group_level = as.character(group_level))
 
     plt2 <- plot_forest(df)
-    vdiffr::expect_doppelganger("Chacter interpretation of numeric group_level", plt2)
+    vdiffr::expect_doppelganger("Character interpretation of numeric group_level", plt2)
 
   })
 })


### PR DESCRIPTION
This PR removes a section that prevented **numeric** `group_levels` from being used. 

Previously, these values would be overwritten with empty quotes:

```r
  suppressWarnings({
    if(any(is.na(as.numeric(y_tick_names)))){
      y_tick_names[!is.na(as.numeric(y_tick_names))] <- ""
    }
  })
```

Its unclear why this design choice was chosen. I imagine it was to prevent numeric levels from being passed though, though I dont see why that would be cause for concern.

**EDIT**: After further inspection, I realized that code I removed was meant to handle no `group_level` being specified. By removing that code, we now get labels when none is supplied (which is not ideal). To fix this, I modified the section below:
```r
  if (is.null(group_level) || length(group_level) != n) {
    if (!is.null(group_level) && length(group_level) != n) {
      warning("Argument group_level has wrong length and is ignored.")
    }
    group_level <- rep("", n) # used to be 1:n()
  }
```

Moving forward, both character interpretations of numeric columns, **and** actual numeric columns can be used:

**Character of `'10.00'`**
![image](https://user-images.githubusercontent.com/18685116/201721278-817796a9-0a6c-40f9-a571-d23c404c3cfb.png)

**Value of `10`**
![image](https://user-images.githubusercontent.com/18685116/201721317-f91850b4-2eef-4bf4-9697-9c6a409cd696.png)


closes #24 