### PR TITLE
Deal with deprecation warnings

### DIFF
--- a/R/summarize-data.R
+++ b/R/summarize-data.R
@@ -134,7 +134,7 @@ summarize_data <- function(
     suppressMessages({
       sum <-
         data %>%
-        group_by(across(c(replicate, all_of(groups)))) %>%
+        group_by(across(c(all_of(replicate), all_of(groups)))) %>%
         summarise(
           mid = stat_func(!!sym(value),statistic),
           lo  = quantile(!!sym(value), lci),


### PR DESCRIPTION
Slight changes to remove depreciation warnings

related to https://github.com/metrumresearchgroup/pmforest/issues/26

This wont close this issue, as we cant fully address the first warning for a while. Will likely wait a few MPN snapshots before addressing it, given that we cant require all users rely on the latest ggplot2 release to be able to use this package