### PR TITLE
Add support for ggplot2 3.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Depends:
     R (>= 3.5.0)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.2
 VignetteBuilder: knitr
 Collate: 
     'classicforest.R'

--- a/R/classicforest.R
+++ b/R/classicforest.R
@@ -97,10 +97,10 @@ classicforest <- function(plotdata,
   x_max <- NULL
 
   shape_value <- switch(shapes,
-                   "square" = 22,
-                   "diamond" = 23,
-                   "circle" = 21,
-                   "triangle" = 24
+                        "square" = 22,
+                        "diamond" = 23,
+                        "circle" = 21,
+                        "triangle" = 24
   )
 
   # create classic forest plot
@@ -151,25 +151,25 @@ classicforest <- function(plotdata,
     if(jitter_reps){
       p1 <- p1 +
         geom_point(aes(x=lo_mid, color=factor(group)), position = position_nudge(y = 0.3), size=0.1) +
-        geom_linerange(data=plotdata, aes(xmin = lo_lo, xmax = lo_hi, color=factor(group)),
-                       position = position_nudge(y = 0.3), size=0.7) +
+        linerange(data=plotdata, aes(xmin = lo_lo, xmax = lo_hi, color=factor(group)),
+                  position = position_nudge(y = 0.3), linewidth=0.7) +
         geom_point(aes(x=hi_mid, color=factor(group)), position = position_nudge(y = 0.55), size=0.1) +
-        geom_linerange(data=plotdata, aes(xmin = hi_lo, xmax = hi_hi, color=factor(group)),
-                       position = position_nudge(y = 0.55), size=0.7) +
+        linerange(data=plotdata, aes(xmin = hi_lo, xmax = hi_hi, color=factor(group)),
+                  position = position_nudge(y = 0.55), linewidth=0.7) +
         geom_point(aes(x=mid_mid, color=factor(group)), position = position_nudge(y = 0.425), size=0.1) +
-        geom_linerange(data=plotdata, aes(xmin = mid_lo, xmax = mid_hi, color=factor(group)),
-                       position = position_nudge(y = 0.425), size=0.7)
+        linerange(data=plotdata, aes(xmin = mid_lo, xmax = mid_hi, color=factor(group)),
+                  position = position_nudge(y = 0.425), linewidth=0.7)
     }else{
       p1 <- p1 +
         geom_point(aes(x=lo_mid, color=factor(group)), position = position_nudge(y = 0.5), size=0.1) +
-        geom_linerange(data=plotdata, aes(xmin = lo_lo, xmax = lo_hi, color=factor(group)),
-                       position = position_nudge(y = 0.5), size=0.7) +
+        linerange(data=plotdata, aes(xmin = lo_lo, xmax = lo_hi, color=factor(group)),
+                  position = position_nudge(y = 0.5), linewidth=0.7) +
         geom_point(aes(x=hi_mid, color=factor(group)), position = position_nudge(y = 0.5), size=0.1) +
-        geom_linerange(data=plotdata, aes(xmin = hi_lo, xmax = hi_hi, color=factor(group)),
-                       position = position_nudge(y = 0.5), size=0.7) +
+        linerange(data=plotdata, aes(xmin = hi_lo, xmax = hi_hi, color=factor(group)),
+                  position = position_nudge(y = 0.5), linewidth=0.7) +
         geom_point(aes(x=mid_mid, color=factor(group)), position = position_nudge(y = 0.5), size=0.1) +
-        geom_linerange(data=plotdata, aes(xmin = mid_lo, xmax = mid_hi, color=factor(group)),
-                       position = position_nudge(y = 0.5), size=0.7)
+        linerange(data=plotdata, aes(xmin = mid_lo, xmax = mid_hi, color=factor(group)),
+                  position = position_nudge(y = 0.5), linewidth=0.7)
     }
 
   }
@@ -212,4 +212,15 @@ classicforest <- function(plotdata,
     ) #+ scale_fill_manual(values = col)
 
   p2
+}
+
+# the size attribute was changed to linewidth for geom_line related functions in ggplot2 3.4.0
+# size is deprecated, but will still be supported in subsequent versions.
+# Ensure package doesnt break when ggplot stops supporting size for line related geoms
+if (utils::packageVersion("ggplot2") >= "3.4.0") {
+  linerange <- geom_linerange
+} else {
+  linerange <- function(..., linewidth = 0.7) {
+    geom_linerange(..., size = linewidth)
+  }
 }


### PR DESCRIPTION
Add support for ggplot2 3.4.0 and subsequent versions, while still supporting earlier versions.

Taken from their latest [release](https://github.com/tidyverse/ggplot2/releases):
> A linewidth aesthetic has been introduced and supersedes the size
aesthetic for scaling the width of lines in line based geoms. size will
remain functioning but deprecated for these geoms and it is recommended to
update all code to reflect the new aesthetic. For geoms that have both point
sizing and linewidth sizing (geom_pointrange() and geom_sf) size now
only refers to sizing of points which can leads to a visual change in old
code (@thomasp85, https://github.com/tidyverse/ggplot2/pull/3672) 

In other words, we need to ensure that both `size` and `linewidth` attributes are supported for line related `_geoms`. `geom_linerange()` was the only affected function `pmforest` relies on.

closes #26 