### PR TITLE
Option to specify open and closed intervals for CI table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Depends:
     R (>= 3.5.0)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 Collate: 
     'classicforest.R'

--- a/R/forest-constructor.R
+++ b/R/forest-constructor.R
@@ -18,6 +18,8 @@ forest_constructor <- function(data,
                                plot_width,
                                facet_titles = NULL,
                                CI_label = NULL,
+                               CI_bracket_open,
+                               CI_bracket_close,
                                table_layout = NULL,
                                text_size = 3,
                                x_limit = NULL,
@@ -236,7 +238,7 @@ forest_constructor <- function(data,
     x_hat <- pmtables::sig(x_hat, digits = digits, maxex = maxex)
 
     CI <- c(
-      paste(x_hat, " [", lb, ", ", ub, "]", sep = ""),
+      paste(x_hat, " ", CI_bracket_open, lb, ", ", ub, CI_bracket_close, sep = ""),
       summary_label
     )
     CI_label <- data.frame(CI = CI, stringsAsFactors = FALSE)

--- a/R/plot-forest.R
+++ b/R/plot-forest.R
@@ -13,7 +13,9 @@
 #' @param maxex numeric. Maximum number of significant digits before moving to scientific notation. Passed through to [pmtables::sig()].
 #' @param x_lab string. x-axis label.
 #' @param y_lab string. Default is not to label y axis.
-#' @param CI_label string. Ignored if `annotate_CI` is `FALSE`.
+#' @param CI_label string. Label above the CI table. Ignored if `annotate_CI` is `FALSE`.
+#' @param CI_bracket_open string. Denotes whether to use brackets (`[`) or parentheses (`(`) for the **opening** interval. Ignored if `annotate_CI` is `FALSE`.
+#' @param CI_bracket_close string. Denotes whether to use brackets (`]`) or parentheses (`)`) for the **closing** interval. Ignored if `annotate_CI` is `FALSE`.
 #' @param caption string. A patchwork styled caption for the overall plot.
 #' @param text_size numeric. Text size for labels. Must be at least 3.5
 #' @param plot_width numeric. Value between 1 and 12 to denote the ratio of plot : CI table
@@ -40,6 +42,8 @@ plot_forest <- function(data,
                         x_lab = "Effect",
                         y_lab = NULL,
                         CI_label = NULL,
+                        CI_bracket_open = c("[", "("),
+                        CI_bracket_close = c("]", ")"),
                         caption = NULL,
                         text_size = 3.5,
                         plot_width = 8,
@@ -60,6 +64,8 @@ plot_forest <- function(data,
   assert_that(all(class(ggplot_theme) == c("theme", "gg")), msg = "`ggplot_theme` must be a ggplot theme. See `?ggplot2::theme` for details.")
   shapes <- match.arg(shapes)
   assert_that(is.numeric(shape_size) & shape_size >= 1 & shape_size <= 4, msg = "`shape_size` must be a numeric value between 1 and 4")
+  CI_bracket_open <- match.arg(CI_bracket_open)
+  CI_bracket_close <- match.arg(CI_bracket_close)
 
   # TODO: this will be refactored once we refactor some of the downstream code
   if (all(VALUE_COLS %in% names(data))) {
@@ -90,7 +96,7 @@ plot_forest <- function(data,
 
   ignored_cols <- names(data)[!(names(data) %in% c("group", "group_level", "metagroup", args))]
   if(length(ignored_cols) > 0){
-    warning(paste(
+    message(paste(
       glue("`data` has extra columns that will be ignored:  {paste(ignored_cols, collapse = ', ')}"),
       "If these were intended to be grouping columns, they must be named either `group`, `group_level`, or `metagroup`.",
       "See `?summarize_data` for more detail.",
@@ -116,6 +122,8 @@ plot_forest <- function(data,
       plot_width = plot_width,
       facet_titles = "",
       CI_label = CI_label,
+      CI_bracket_open = CI_bracket_open,
+      CI_bracket_close = CI_bracket_close,
       text_size = text_size,
       x_limit = x_limit,
       x_breaks = x_breaks,
@@ -161,6 +169,8 @@ plot_forest <- function(data,
           plot_width = plot_width,
           facet_titles = .y,
           CI_label = CI_label,
+          CI_bracket_open = CI_bracket_open,
+          CI_bracket_close = CI_bracket_close,
           text_size = text_size,
           x_limit = x_limit,
           x_breaks = x_breaks,

--- a/man/forest_constructor.Rd
+++ b/man/forest_constructor.Rd
@@ -19,6 +19,8 @@ forest_constructor(
   plot_width,
   facet_titles = NULL,
   CI_label = NULL,
+  CI_bracket_open,
+  CI_bracket_close,
   table_layout = NULL,
   text_size = 3,
   x_limit = NULL,
@@ -54,7 +56,11 @@ to plot. This must be in the same format as the tibble that is output by
 
 \item{plot_width}{numeric. Value between 1 and 12 to denote the ratio of plot : CI table}
 
-\item{CI_label}{string. Ignored if \code{annotate_CI} is \code{FALSE}.}
+\item{CI_label}{string. Label above the CI table. Ignored if \code{annotate_CI} is \code{FALSE}.}
+
+\item{CI_bracket_open}{string. Denotes whether to use brackets (\code{[}) or parentheses (\code{(}) for the \strong{opening} interval. Ignored if \code{annotate_CI} is \code{FALSE}.}
+
+\item{CI_bracket_close}{string. Denotes whether to use brackets (\verb{]}) or parentheses (\verb{)}) for the \strong{closing} interval. Ignored if \code{annotate_CI} is \code{FALSE}.}
 
 \item{text_size}{numeric. Text size for labels. Must be at least 3.5}
 

--- a/man/plot_forest.Rd
+++ b/man/plot_forest.Rd
@@ -15,6 +15,8 @@ plot_forest(
   x_lab = "Effect",
   y_lab = NULL,
   CI_label = NULL,
+  CI_bracket_open = c("[", "("),
+  CI_bracket_close = c("]", ")"),
   caption = NULL,
   text_size = 3.5,
   plot_width = 8,
@@ -48,7 +50,11 @@ to plot. This must be in the same format as the tibble that is output by
 
 \item{y_lab}{string. Default is not to label y axis.}
 
-\item{CI_label}{string. Ignored if \code{annotate_CI} is \code{FALSE}.}
+\item{CI_label}{string. Label above the CI table. Ignored if \code{annotate_CI} is \code{FALSE}.}
+
+\item{CI_bracket_open}{string. Denotes whether to use brackets (\code{[}) or parentheses (\code{(}) for the \strong{opening} interval. Ignored if \code{annotate_CI} is \code{FALSE}.}
+
+\item{CI_bracket_close}{string. Denotes whether to use brackets (\verb{]}) or parentheses (\verb{)}) for the \strong{closing} interval. Ignored if \code{annotate_CI} is \code{FALSE}.}
 
 \item{caption}{string. A patchwork styled caption for the overall plot.}
 

--- a/tests/testthat/_snaps/base-plot/change-ci-interval-format-change-both.svg
+++ b/tests/testthat/_snaps/base-plot/change-ci-interval-format-change-both.svg
@@ -1,0 +1,187 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNjEuMDV8NzAzLjU2fDQ0LjQxfDU0MS4zNw=='>
+    <rect x='61.05' y='44.41' width='642.51' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjEuMDV8NzAzLjU2fDQ0LjQxfDU0MS4zNw==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw0ODAuMTV8MjIuNzh8NTcwLjUy'>
+    <rect x='5.48' y='22.78' width='474.67' height='547.74' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw0ODAuMTV8MjIuNzh8NTcwLjUy)'>
+<rect x='5.48' y='22.78' width='474.67' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNjEuMDV8NDc5LjE1fDQ0LjQxfDU0MS4zNw=='>
+    <rect x='61.05' y='44.41' width='418.10' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjEuMDV8NDc5LjE1fDQ0LjQxfDU0MS4zNw==)'>
+<rect x='61.05' y='44.41' width='418.10' height='496.97' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='98.59,541.37 98.59,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='208.70,541.37 208.70,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='318.80,541.37 318.80,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='428.90,541.37 428.90,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='153.64,541.37 153.64,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='263.75,541.37 263.75,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='373.85,541.37 373.85,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='-176.67' y1='541.37' x2='-176.67' y2='44.41' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27,5.69,4.27; stroke-linecap: butt;' />
+<polyline points='421.73,468.65 421.73,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='421.73,468.65 355.15,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='355.15,468.65 355.15,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='382.46,444.40 382.46,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='382.46,444.40 353.61,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='353.61,444.40 353.61,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='317.63,371.68 317.63,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='317.63,371.68 285.00,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='285.00,371.68 285.00,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='406.13,347.43 406.13,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='406.13,347.43 393.39,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='393.39,347.43 393.39,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='332.68,274.71 332.68,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='332.68,274.71 320.77,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='320.77,274.71 320.77,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='225.66,250.47 225.66,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='225.66,250.47 189.04,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='189.04,250.47 189.04,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='130.08,226.22 130.08,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='130.08,226.22 80.06,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='80.06,226.22 80.06,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='282.76,153.50 282.76,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='282.76,153.50 282.76,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='282.76,153.50 282.76,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='460.15,129.26 460.15,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='460.15,129.26 460.15,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='460.15,129.26 460.15,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polygon points='384.99,473.77 390.11,468.65 384.99,463.52 379.86,468.65 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='368.92,449.53 374.05,444.40 368.92,439.28 363.80,444.40 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='302.31,376.80 307.43,371.68 302.31,366.55 297.18,371.68 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='399.23,352.56 404.35,347.43 399.23,342.31 394.11,347.43 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='327.06,279.83 332.18,274.71 327.06,269.58 321.93,274.71 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='208.04,255.59 213.17,250.47 208.04,245.34 202.92,250.47 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='105.50,231.35 110.63,226.22 105.50,221.10 100.38,226.22 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='282.76,158.62 287.89,153.50 282.76,148.37 277.64,153.50 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<polygon points='460.15,134.38 465.27,129.26 460.15,124.13 455.02,129.26 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<line x1='61.05' y1='92.89' x2='479.15' y2='92.89' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='61.05' y1='189.86' x2='479.15' y2='189.86' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='61.05' y1='311.07' x2='479.15' y2='311.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='61.05' y1='408.04' x2='479.15' y2='408.04' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='61.05' y='44.41' width='418.10' height='496.97' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='56.12' y='95.62' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='12.34px' lengthAdjust='spacingAndGlyphs'>WT</text>
+<text x='56.12' y='131.99' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='19.42px' lengthAdjust='spacingAndGlyphs'>85 kg</text>
+<text x='56.12' y='156.23' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='19.42px' lengthAdjust='spacingAndGlyphs'>55 kg</text>
+<text x='56.12' y='192.59' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='22.05px' lengthAdjust='spacingAndGlyphs'>EGFR</text>
+<text x='56.12' y='228.95' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='25.15px' lengthAdjust='spacingAndGlyphs'>Severe</text>
+<text x='56.12' y='253.20' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='33.54px' lengthAdjust='spacingAndGlyphs'>Moderate</text>
+<text x='56.12' y='277.44' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='14.55px' lengthAdjust='spacingAndGlyphs'>Mild</text>
+<text x='56.12' y='313.80' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='15.01px' lengthAdjust='spacingAndGlyphs'>ALB</text>
+<text x='56.12' y='350.17' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='22.07px' lengthAdjust='spacingAndGlyphs'>5 g/dL</text>
+<text x='56.12' y='374.41' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='33.10px' lengthAdjust='spacingAndGlyphs'>3.25 g/dL</text>
+<text x='56.12' y='410.77' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='16.77px' lengthAdjust='spacingAndGlyphs'>AGE</text>
+<text x='56.12' y='447.13' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='30.45px' lengthAdjust='spacingAndGlyphs'>45 years</text>
+<text x='56.12' y='471.38' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='30.45px' lengthAdjust='spacingAndGlyphs'>20 years</text>
+<polyline points='58.31,92.89 61.05,92.89 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,129.26 61.05,129.26 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,153.50 61.05,153.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,189.86 61.05,189.86 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,226.22 61.05,226.22 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,250.47 61.05,250.47 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,274.71 61.05,274.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,311.07 61.05,311.07 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,347.43 61.05,347.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,371.68 61.05,371.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,408.04 61.05,408.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,444.40 61.05,444.40 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,468.65 61.05,468.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='153.64,544.11 153.64,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='263.75,544.11 263.75,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='373.85,544.11 373.85,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='153.64' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='263.75' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='373.85' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='270.10' y='562.98' text-anchor='middle' style='font-size: 9.92px; font-family: sans;' textLength='25.37px' lengthAdjust='spacingAndGlyphs'>Effect</text>
+<text x='61.05' y='36.46' style='font-size: 11.91px; font-family: sans;' textLength='15.22px' lengthAdjust='spacingAndGlyphs'>CL</text>
+</g>
+<defs>
+  <clipPath id='cpNDgwLjE1fDcxNC41MnwyMi43OHw1NzAuNTI='>
+    <rect x='480.15' y='22.78' width='234.37' height='547.74' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDgwLjE1fDcxNC41MnwyMi43OHw1NzAuNTI=)'>
+<rect x='480.15' y='22.78' width='234.37' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjUxfDcwMy41Nnw0NC40MXw1NDEuMzc='>
+    <rect x='494.51' y='44.41' width='209.05' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjUxfDcwMy41Nnw0NC40MXw1NDEuMzc=)'>
+<rect x='494.51' y='44.41' width='209.05' height='496.97' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='494.51' y='92.89' style='font-size: 7.97px; font-family: sans;' textLength='12.39px' lengthAdjust='spacingAndGlyphs'>WT</text>
+<text x='494.51' y='129.26' style='font-size: 7.97px; font-family: sans;' textLength='58.46px' lengthAdjust='spacingAndGlyphs'>1.16 (1.16, 1.16)</text>
+<text x='494.51' y='153.50' style='font-size: 7.97px; font-family: sans;' textLength='71.76px' lengthAdjust='spacingAndGlyphs'>0.835 (0.835, 0.835)</text>
+<text x='494.51' y='189.86' style='font-size: 7.97px; font-family: sans;' textLength='22.14px' lengthAdjust='spacingAndGlyphs'>EGFR</text>
+<text x='494.51' y='226.22' style='font-size: 7.97px; font-family: sans;' textLength='71.76px' lengthAdjust='spacingAndGlyphs'>0.513 (0.466, 0.557)</text>
+<text x='494.51' y='250.47' style='font-size: 7.97px; font-family: sans;' textLength='71.76px' lengthAdjust='spacingAndGlyphs'>0.699 (0.664, 0.731)</text>
+<text x='494.51' y='274.71' style='font-size: 7.97px; font-family: sans;' textLength='71.76px' lengthAdjust='spacingAndGlyphs'>0.915 (0.904, 0.925)</text>
+<text x='494.51' y='311.07' style='font-size: 7.97px; font-family: sans;' textLength='15.06px' lengthAdjust='spacingAndGlyphs'>ALB</text>
+<text x='494.51' y='347.43' style='font-size: 7.97px; font-family: sans;' textLength='58.46px' lengthAdjust='spacingAndGlyphs'>1.05 (1.04, 1.06)</text>
+<text x='494.51' y='371.68' style='font-size: 7.97px; font-family: sans;' textLength='71.76px' lengthAdjust='spacingAndGlyphs'>0.870 (0.839, 0.898)</text>
+<text x='494.51' y='408.04' style='font-size: 7.97px; font-family: sans;' textLength='16.83px' lengthAdjust='spacingAndGlyphs'>AGE</text>
+<text x='494.51' y='444.40' style='font-size: 7.97px; font-family: sans;' textLength='67.33px' lengthAdjust='spacingAndGlyphs'>0.991 (0.963, 1.02)</text>
+<text x='494.51' y='468.65' style='font-size: 7.97px; font-family: sans;' textLength='62.90px' lengthAdjust='spacingAndGlyphs'>1.02 (0.966, 1.09)</text>
+<line x1='494.51' y1='100.16' x2='703.56' y2='100.16' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='494.51' y1='197.13' x2='703.56' y2='197.13' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='494.51' y1='318.34' x2='703.56' y2='318.34' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='494.51' y1='415.31' x2='703.56' y2='415.31' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='494.51,541.37 703.56,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.51,544.11 494.51,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='536.32,544.11 536.32,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='578.13,544.11 578.13,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='619.94,544.11 619.94,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='661.75,544.11 661.75,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='703.56,544.11 703.56,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='494.51' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='536.32' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='578.13' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='619.94' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.3</text>
+<text x='661.75' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='703.56' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='494.51' y='36.46' style='font-size: 11.91px; font-family: sans;' textLength='30.44px' lengthAdjust='spacingAndGlyphs'>Effect</text>
+<text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='234.82px' lengthAdjust='spacingAndGlyphs'>Change CI interval format - change both</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/base-plot/change-ci-interval-format-mixed.svg
+++ b/tests/testthat/_snaps/base-plot/change-ci-interval-format-mixed.svg
@@ -1,0 +1,187 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNjEuMDV8NzAzLjU2fDQ0LjQxfDU0MS4zNw=='>
+    <rect x='61.05' y='44.41' width='642.51' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjEuMDV8NzAzLjU2fDQ0LjQxfDU0MS4zNw==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw0ODAuMTV8MjIuNzh8NTcwLjUy'>
+    <rect x='5.48' y='22.78' width='474.67' height='547.74' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw0ODAuMTV8MjIuNzh8NTcwLjUy)'>
+<rect x='5.48' y='22.78' width='474.67' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNjEuMDV8NDc5LjE1fDQ0LjQxfDU0MS4zNw=='>
+    <rect x='61.05' y='44.41' width='418.10' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjEuMDV8NDc5LjE1fDQ0LjQxfDU0MS4zNw==)'>
+<rect x='61.05' y='44.41' width='418.10' height='496.97' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='98.59,541.37 98.59,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='208.70,541.37 208.70,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='318.80,541.37 318.80,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='428.90,541.37 428.90,44.41 ' style='stroke-width: 0.53; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='153.64,541.37 153.64,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='263.75,541.37 263.75,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polyline points='373.85,541.37 373.85,44.41 ' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='-176.67' y1='541.37' x2='-176.67' y2='44.41' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27,5.69,4.27; stroke-linecap: butt;' />
+<polyline points='421.73,468.65 421.73,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='421.73,468.65 355.15,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='355.15,468.65 355.15,468.65 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='382.46,444.40 382.46,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='382.46,444.40 353.61,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='353.61,444.40 353.61,444.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='317.63,371.68 317.63,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='317.63,371.68 285.00,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='285.00,371.68 285.00,371.68 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='406.13,347.43 406.13,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='406.13,347.43 393.39,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='393.39,347.43 393.39,347.43 ' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt;' />
+<polyline points='332.68,274.71 332.68,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='332.68,274.71 320.77,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='320.77,274.71 320.77,274.71 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='225.66,250.47 225.66,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='225.66,250.47 189.04,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='189.04,250.47 189.04,250.47 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='130.08,226.22 130.08,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='130.08,226.22 80.06,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='80.06,226.22 80.06,226.22 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='282.76,153.50 282.76,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='282.76,153.50 282.76,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='282.76,153.50 282.76,153.50 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='460.15,129.26 460.15,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='460.15,129.26 460.15,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polyline points='460.15,129.26 460.15,129.26 ' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt;' />
+<polygon points='384.99,473.77 390.11,468.65 384.99,463.52 379.86,468.65 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='368.92,449.53 374.05,444.40 368.92,439.28 363.80,444.40 ' style='stroke-width: 0.71; fill: #F8766D;' />
+<polygon points='302.31,376.80 307.43,371.68 302.31,366.55 297.18,371.68 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='399.23,352.56 404.35,347.43 399.23,342.31 394.11,347.43 ' style='stroke-width: 0.71; fill: #7CAE00;' />
+<polygon points='327.06,279.83 332.18,274.71 327.06,269.58 321.93,274.71 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='208.04,255.59 213.17,250.47 208.04,245.34 202.92,250.47 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='105.50,231.35 110.63,226.22 105.50,221.10 100.38,226.22 ' style='stroke-width: 0.71; fill: #00BFC4;' />
+<polygon points='282.76,158.62 287.89,153.50 282.76,148.37 277.64,153.50 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<polygon points='460.15,134.38 465.27,129.26 460.15,124.13 455.02,129.26 ' style='stroke-width: 0.71; fill: #C77CFF;' />
+<line x1='61.05' y1='92.89' x2='479.15' y2='92.89' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='61.05' y1='189.86' x2='479.15' y2='189.86' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='61.05' y1='311.07' x2='479.15' y2='311.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='61.05' y1='408.04' x2='479.15' y2='408.04' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='61.05' y='44.41' width='418.10' height='496.97' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='56.12' y='95.62' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='12.34px' lengthAdjust='spacingAndGlyphs'>WT</text>
+<text x='56.12' y='131.99' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='19.42px' lengthAdjust='spacingAndGlyphs'>85 kg</text>
+<text x='56.12' y='156.23' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='19.42px' lengthAdjust='spacingAndGlyphs'>55 kg</text>
+<text x='56.12' y='192.59' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='22.05px' lengthAdjust='spacingAndGlyphs'>EGFR</text>
+<text x='56.12' y='228.95' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='25.15px' lengthAdjust='spacingAndGlyphs'>Severe</text>
+<text x='56.12' y='253.20' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='33.54px' lengthAdjust='spacingAndGlyphs'>Moderate</text>
+<text x='56.12' y='277.44' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='14.55px' lengthAdjust='spacingAndGlyphs'>Mild</text>
+<text x='56.12' y='313.80' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='15.01px' lengthAdjust='spacingAndGlyphs'>ALB</text>
+<text x='56.12' y='350.17' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='22.07px' lengthAdjust='spacingAndGlyphs'>5 g/dL</text>
+<text x='56.12' y='374.41' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='33.10px' lengthAdjust='spacingAndGlyphs'>3.25 g/dL</text>
+<text x='56.12' y='410.77' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='16.77px' lengthAdjust='spacingAndGlyphs'>AGE</text>
+<text x='56.12' y='447.13' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='30.45px' lengthAdjust='spacingAndGlyphs'>45 years</text>
+<text x='56.12' y='471.38' text-anchor='end' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='30.45px' lengthAdjust='spacingAndGlyphs'>20 years</text>
+<polyline points='58.31,92.89 61.05,92.89 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,129.26 61.05,129.26 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,153.50 61.05,153.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,189.86 61.05,189.86 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,226.22 61.05,226.22 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,250.47 61.05,250.47 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,274.71 61.05,274.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,311.07 61.05,311.07 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,347.43 61.05,347.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,371.68 61.05,371.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,408.04 61.05,408.04 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,444.40 61.05,444.40 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='58.31,468.65 61.05,468.65 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='153.64,544.11 153.64,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='263.75,544.11 263.75,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='373.85,544.11 373.85,541.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='153.64' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='263.75' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='373.85' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #4D4D4D; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='270.10' y='562.98' text-anchor='middle' style='font-size: 9.92px; font-family: sans;' textLength='25.37px' lengthAdjust='spacingAndGlyphs'>Effect</text>
+<text x='61.05' y='36.46' style='font-size: 11.91px; font-family: sans;' textLength='15.22px' lengthAdjust='spacingAndGlyphs'>CL</text>
+</g>
+<defs>
+  <clipPath id='cpNDgwLjE1fDcxNC41MnwyMi43OHw1NzAuNTI='>
+    <rect x='480.15' y='22.78' width='234.37' height='547.74' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDgwLjE1fDcxNC41MnwyMi43OHw1NzAuNTI=)'>
+<rect x='480.15' y='22.78' width='234.37' height='547.74' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjUxfDcwMy41Nnw0NC40MXw1NDEuMzc='>
+    <rect x='494.51' y='44.41' width='209.05' height='496.97' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjUxfDcwMy41Nnw0NC40MXw1NDEuMzc=)'>
+<rect x='494.51' y='44.41' width='209.05' height='496.97' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='494.51' y='92.89' style='font-size: 7.97px; font-family: sans;' textLength='12.39px' lengthAdjust='spacingAndGlyphs'>WT</text>
+<text x='494.51' y='129.26' style='font-size: 7.97px; font-family: sans;' textLength='58.03px' lengthAdjust='spacingAndGlyphs'>1.16 [1.16, 1.16)</text>
+<text x='494.51' y='153.50' style='font-size: 7.97px; font-family: sans;' textLength='71.32px' lengthAdjust='spacingAndGlyphs'>0.835 [0.835, 0.835)</text>
+<text x='494.51' y='189.86' style='font-size: 7.97px; font-family: sans;' textLength='22.14px' lengthAdjust='spacingAndGlyphs'>EGFR</text>
+<text x='494.51' y='226.22' style='font-size: 7.97px; font-family: sans;' textLength='71.32px' lengthAdjust='spacingAndGlyphs'>0.513 [0.466, 0.557)</text>
+<text x='494.51' y='250.47' style='font-size: 7.97px; font-family: sans;' textLength='71.32px' lengthAdjust='spacingAndGlyphs'>0.699 [0.664, 0.731)</text>
+<text x='494.51' y='274.71' style='font-size: 7.97px; font-family: sans;' textLength='71.32px' lengthAdjust='spacingAndGlyphs'>0.915 [0.904, 0.925)</text>
+<text x='494.51' y='311.07' style='font-size: 7.97px; font-family: sans;' textLength='15.06px' lengthAdjust='spacingAndGlyphs'>ALB</text>
+<text x='494.51' y='347.43' style='font-size: 7.97px; font-family: sans;' textLength='58.03px' lengthAdjust='spacingAndGlyphs'>1.05 [1.04, 1.06)</text>
+<text x='494.51' y='371.68' style='font-size: 7.97px; font-family: sans;' textLength='71.32px' lengthAdjust='spacingAndGlyphs'>0.870 [0.839, 0.898)</text>
+<text x='494.51' y='408.04' style='font-size: 7.97px; font-family: sans;' textLength='16.83px' lengthAdjust='spacingAndGlyphs'>AGE</text>
+<text x='494.51' y='444.40' style='font-size: 7.97px; font-family: sans;' textLength='66.89px' lengthAdjust='spacingAndGlyphs'>0.991 [0.963, 1.02)</text>
+<text x='494.51' y='468.65' style='font-size: 7.97px; font-family: sans;' textLength='62.46px' lengthAdjust='spacingAndGlyphs'>1.02 [0.966, 1.09)</text>
+<line x1='494.51' y1='100.16' x2='703.56' y2='100.16' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='494.51' y1='197.13' x2='703.56' y2='197.13' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='494.51' y1='318.34' x2='703.56' y2='318.34' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='494.51' y1='415.31' x2='703.56' y2='415.31' style='stroke-width: 1.07; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='494.51,541.37 703.56,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.51,544.11 494.51,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='536.32,544.11 536.32,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='578.13,544.11 578.13,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='619.94,544.11 619.94,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='661.75,544.11 661.75,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='703.56,544.11 703.56,541.37 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='494.51' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='536.32' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='578.13' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='619.94' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.3</text>
+<text x='661.75' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='703.56' y='551.77' text-anchor='middle' style='font-size: 7.94px; fill: #FFFFFF; font-family: sans;' textLength='11.03px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='494.51' y='36.46' style='font-size: 11.91px; font-family: sans;' textLength='30.44px' lengthAdjust='spacingAndGlyphs'>Effect</text>
+<text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='197.37px' lengthAdjust='spacingAndGlyphs'>Change CI interval format - mixed</text>
+</g>
+</svg>

--- a/tests/testthat/test-base-plot.R
+++ b/tests/testthat/test-base-plot.R
@@ -315,14 +315,12 @@ describe("Base plots", {
     plt <- plot_forest(data = sumData,
                        CI_bracket_open = "[",
                        CI_bracket_close = ")"
-
     )
     vdiffr::expect_doppelganger("Change CI interval format - mixed", plt)
 
     plt <- plot_forest(data = sumData,
                        CI_bracket_open = "(",
                        CI_bracket_close = ")"
-
     )
     vdiffr::expect_doppelganger("Change CI interval format - change both", plt)
 

--- a/tests/testthat/test-base-plot.R
+++ b/tests/testthat/test-base-plot.R
@@ -308,6 +308,33 @@ describe("Base plots", {
     vdiffr::expect_doppelganger("Character interpretation of numeric group_level", plt2)
 
   })
+
+  it("Change CI interval format [PMF-PLOT-025]", {
+    skip_on_cran()
+    skip_vdiffr()
+    plt <- plot_forest(data = sumData,
+                       CI_bracket_open = "[",
+                       CI_bracket_close = ")"
+
+    )
+    vdiffr::expect_doppelganger("Change CI interval format - mixed", plt)
+
+    plt <- plot_forest(data = sumData,
+                       CI_bracket_open = "(",
+                       CI_bracket_close = ")"
+
+    )
+    vdiffr::expect_doppelganger("Change CI interval format - change both", plt)
+
+    # error
+    error_msg <- capture_error(
+      plot_forest(data = sumData, CI_bracket_open = "]", CI_bracket_close = "]")
+    )
+    expect_true(
+      grepl("'arg' should be one of", error_msg$message)
+    )
+
+  })
 })
 
 

--- a/tests/testthat/test-base-plot.R
+++ b/tests/testthat/test-base-plot.R
@@ -325,12 +325,10 @@ describe("Base plots", {
     vdiffr::expect_doppelganger("Change CI interval format - change both", plt)
 
     # error
-    error_msg <- capture_error(
-      plot_forest(data = sumData, CI_bracket_open = "]", CI_bracket_close = "]")
-    )
-    expect_true(
-      grepl("'arg' should be one of", error_msg$message)
-    )
+    expect_error(
+      plot_forest(data = sumData, CI_bracket_open = "]", CI_bracket_close = "]"),
+      "'arg' should be one of"
+      )
 
   })
 })

--- a/tests/testthat/test-input-data.R
+++ b/tests/testthat/test-input-data.R
@@ -33,7 +33,7 @@ test_that("plot_forest() input data check warns with extra columns [PMF-DATA-004
       hi = c(5, 6, 7),
       naw = c(7, 8, 9)
     )
-  expect_warning(
+  expect_message(
     plt <- plot_forest(df),
     "has extra columns"
   )


### PR DESCRIPTION
This PR introduces two new arguments, `CI_bracket_open` & `CI_bracket_close`, which allow users to specify whether to use brackets (`[]`) or parentheses (`()`) for the opening and closing interval respectively. Users can mix and match between the two options to denote whether the interval includes the endpoint on the left or right of the interval, though it primarily serves as a formatting option.

## Examples

### using parentheses
```r
plot_forest(
  data = sumData,
  CI_bracket_open = "(",
  CI_bracket_close = ")"
)
```
![image](https://github.com/metrumresearchgroup/pmforest/assets/18685116/ec11f382-26b2-46ea-9159-61557bcd44bb)

### mixing and matching
```r
plot_forest(
  data = sumData,
  CI_bracket_open = "[",
  CI_bracket_close = ")",
  caption = "The interval is closed on the left, and open on the right",
)
```
![image](https://github.com/metrumresearchgroup/pmforest/assets/18685116/d4d208e5-5eea-4a33-a2e0-a99512779246)


closes https://github.com/metrumresearchgroup/pmforest/issues/31