### PR TITLE
Fix rendering of pkgdown site

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 
 <br>
 
-# pmforest <a href='https:/metrumresearchgroup.github.io/pmforest'><img src='man/figures/logo.png' align="right" height="120" /></a>
+# pmforest <a href='https:/metrumresearchgroup.github.io/pmforest'><img src='man/figures/logo.png' align="right" width="135px"/></a>
 
 <!-- badges: start -->
 [![Build Status](https://github-drone.metrumrg.com/api/badges/metrumresearchgroup/pmforest/status.svg)](https://github-drone.metrumrg.com/metrumresearchgroup/pmforest)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <br>
 
-# pmforest <a href='https:/metrumresearchgroup.github.io/pmforest'><img src='man/figures/logo.png' align="right" height="120" /></a>
+# pmforest <a href='https:/metrumresearchgroup.github.io/pmforest'><img src='man/figures/logo.png' align="right" width="135px"/></a>
 
 <!-- badges: start -->
 


### PR DESCRIPTION
The logo was previously large and took up half the page.

 - adjust readme file to instruct a better formatted logo